### PR TITLE
feat: CodexProxy AT/RT 上传支持

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -16,6 +16,7 @@ CONFIG_KEYS = [
     "luckmail_base_url", "luckmail_api_key", "luckmail_email_type", "luckmail_domain",
     "cpa_api_url", "cpa_api_key",
     "team_manager_url", "team_manager_key",
+    "codex_proxy_url", "codex_proxy_key", "codex_proxy_upload_type",
     "cliproxyapi_management_key",
     "grok2api_url", "grok2api_app_key", "grok2api_pool", "grok2api_quota",
     "kiro_manager_path", "kiro_manager_exe",

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -214,6 +214,15 @@ export default function Accounts() {
     message.success('已复制')
   }
 
+  const getRefreshToken = (record: any): string => {
+    try {
+      const extra = JSON.parse(record.extra_json || '{}')
+      return extra.refresh_token || ''
+    } catch {
+      return ''
+    }
+  }
+
   const exportCsv = () => {
     const header = 'email,password,status,region,cashier_url,created_at'
     const rows = accounts.map((a) => [a.email, a.password, a.status, a.region, a.cashier_url, a.created_at].join(','))
@@ -352,6 +361,22 @@ export default function Accounts() {
           <Button type="text" size="small" icon={<CopyOutlined />} onClick={() => copyText(text)} />
         </Space>
       ),
+    },
+    {
+      title: 'RT',
+      key: 'refresh_token',
+      render: (_: any, record: any) => {
+        const rt = getRefreshToken(record)
+        if (!rt) return <span style={{ color: '#ccc' }}>-</span>
+        return (
+          <Space>
+            <Text style={{ fontFamily: 'monospace', fontSize: 11, filter: 'blur(4px)', maxWidth: 80, overflow: 'hidden', display: 'inline-block', verticalAlign: 'middle' }}>
+              {rt.slice(0, 16)}
+            </Text>
+            <Button type="text" size="small" icon={<CopyOutlined />} onClick={() => copyText(rt)} />
+          </Space>
+        )
+      },
     },
     {
       title: '状态',
@@ -553,22 +578,41 @@ export default function Accounts() {
         maskClosable={false}
       >
         {currentAccount && (
-          <Form form={detailForm} layout="vertical" initialValues={currentAccount}>
-            <Form.Item name="status" label="状态">
-              <Select
-                options={[
-                  { value: 'registered', label: '已注册' },
-                  { value: 'trial', label: '试用中' },
-                  { value: 'subscribed', label: '已订阅' },
-                  { value: 'expired', label: '已过期' },
-                  { value: 'invalid', label: '已失效' },
-                ]}
-              />
-            </Form.Item>
-            <Form.Item name="token" label="Token">
-              <Input.TextArea rows={2} style={{ fontFamily: 'monospace' }} />
-            </Form.Item>
-          </Form>
+          <>
+            <Form form={detailForm} layout="vertical" initialValues={currentAccount}>
+              <Form.Item name="status" label="状态">
+                <Select
+                  options={[
+                    { value: 'registered', label: '已注册' },
+                    { value: 'trial', label: '试用中' },
+                    { value: 'subscribed', label: '已订阅' },
+                    { value: 'expired', label: '已过期' },
+                    { value: 'invalid', label: '已失效' },
+                  ]}
+                />
+              </Form.Item>
+              <Form.Item name="token" label="Access Token">
+                <Input.TextArea rows={2} style={{ fontFamily: 'monospace' }} />
+              </Form.Item>
+            </Form>
+            {(() => {
+              const rt = getRefreshToken(currentAccount)
+              if (!rt) return null
+              return (
+                <div style={{ marginTop: 8 }}>
+                  <div style={{ marginBottom: 4, fontWeight: 500, fontSize: 13 }}>Refresh Token</div>
+                  <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, background: 'rgba(0,0,0,0.03)', border: '1px solid #e5e7eb', borderRadius: 6, padding: '6px 10px' }}>
+                    <Text
+                      style={{ fontFamily: 'monospace', fontSize: 11, wordBreak: 'break-all', flex: 1, userSelect: 'text' }}
+                      copyable={{ text: rt, tooltips: ['复制 RT', '已复制'] }}
+                    >
+                      {rt}
+                    </Text>
+                  </div>
+                </div>
+              )
+            })()}
+          </>
         )}
       </Modal>
     </div>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -33,6 +33,10 @@ const SELECT_FIELDS: Record<string, { label: string; value: string }[]> = {
     { label: '本地 Solver (Camoufox)', value: 'local_solver' },
     { label: '手动', value: 'manual' },
   ],
+  codex_proxy_upload_type: [
+    { label: 'AT（Access Token，推荐）', value: 'at' },
+    { label: 'RT（Refresh Token）', value: 'rt' },
+  ],
 }
 
 const TAB_ITEMS = [
@@ -152,6 +156,15 @@ const TAB_ITEMS = [
         fields: [
           { key: 'team_manager_url', label: 'API URL', placeholder: 'https://your-tm.example.com' },
           { key: 'team_manager_key', label: 'API Key', secret: true },
+        ],
+      },
+      {
+        title: 'CodexProxy',
+        desc: '注册完成后自动上传到 CodexProxy 管理平台',
+        fields: [
+          { key: 'codex_proxy_url', label: 'API URL', placeholder: 'https://your-codex-proxy.example.com' },
+          { key: 'codex_proxy_key', label: 'Admin Key', secret: true },
+          { key: 'codex_proxy_upload_type', label: '上传类型' },
         ],
       },
     ],

--- a/platforms/chatgpt/cpa_upload.py
+++ b/platforms/chatgpt/cpa_upload.py
@@ -316,6 +316,127 @@ def upload_to_team_manager(
         return False, f"上传异常: {str(e)}"
 
 
+def upload_to_codex_proxy(
+    account,
+    api_url: str = None,
+    api_key: str = None,
+) -> Tuple[bool, str]:
+    """上传单账号到 CodexProxy（通过 refresh_token，不走代理）。
+    api_url / api_key 为空时自动从 ConfigStore 读取。"""
+    if not api_url:
+        api_url = _get_config_value("codex_proxy_url")
+    if not api_key:
+        api_key = _get_config_value("codex_proxy_key")
+    if not api_url:
+        return False, "CodexProxy API URL 未配置"
+    if not api_key:
+        return False, "CodexProxy Admin Key 未配置"
+
+    refresh_token = getattr(account, "refresh_token", "")
+    if not refresh_token:
+        return False, "账号缺少 refresh_token"
+
+    url = api_url.rstrip("/") + "/api/admin/accounts"
+    headers = {
+        "x-admin-key": api_key,
+        "Content-Type": "application/json",
+        "accept": "*/*",
+    }
+    payload = {
+        "refresh_token": refresh_token,
+        "proxy_url": "",
+    }
+
+    try:
+        resp = cffi_requests.post(
+            url,
+            headers=headers,
+            json=payload,
+            proxies=None,
+            verify=False,
+            timeout=30,
+            impersonate="chrome110",
+        )
+        if resp.status_code in (200, 201):
+            try:
+                data = resp.json()
+                msg = data.get("message", "上传成功")
+            except Exception:
+                msg = "上传成功"
+            return True, msg
+        error_msg = f"上传失败: HTTP {resp.status_code}"
+        try:
+            detail = resp.json()
+            if isinstance(detail, dict):
+                error_msg = detail.get("message", error_msg)
+        except Exception:
+            error_msg = f"{error_msg} - {resp.text[:200]}"
+        return False, error_msg
+    except Exception as e:
+        logger.error(f"CodexProxy 上传异常: {e}")
+        return False, f"上传异常: {str(e)}"
+
+
+def upload_at_to_codex_proxy(
+    account,
+    api_url: str = None,
+    api_key: str = None,
+) -> Tuple[bool, str]:
+    """上传单账号到 CodexProxy（通过 access_token，走 /api/admin/accounts/at）。"""
+    if not api_url:
+        api_url = _get_config_value("codex_proxy_url")
+    if not api_key:
+        api_key = _get_config_value("codex_proxy_key")
+    if not api_url:
+        return False, "CodexProxy API URL 未配置"
+    if not api_key:
+        return False, "CodexProxy Admin Key 未配置"
+
+    access_token = getattr(account, "access_token", "")
+    if not access_token:
+        return False, "账号缺少 access_token"
+
+    url = api_url.rstrip("/") + "/api/admin/accounts/at"
+    headers = {
+        "x-admin-key": api_key,
+        "Content-Type": "application/json",
+        "accept": "*/*",
+    }
+    payload = {
+        "access_token": access_token,
+        "proxy_url": "",
+    }
+
+    try:
+        resp = cffi_requests.post(
+            url,
+            headers=headers,
+            json=payload,
+            proxies=None,
+            verify=False,
+            timeout=30,
+            impersonate="chrome110",
+        )
+        if resp.status_code in (200, 201):
+            try:
+                data = resp.json()
+                msg = data.get("message", "上传成功")
+            except Exception:
+                msg = "上传成功"
+            return True, msg
+        error_msg = f"上传失败: HTTP {resp.status_code}"
+        try:
+            detail = resp.json()
+            if isinstance(detail, dict):
+                error_msg = detail.get("message", error_msg)
+        except Exception:
+            error_msg = f"{error_msg} - {resp.text[:200]}"
+        return False, error_msg
+    except Exception as e:
+        logger.error(f"CodexProxy AT 上传异常: {e}")
+        return False, f"上传异常: {str(e)}"
+
+
 def test_cpa_connection(api_url: str, api_token: str, proxy: str = None) -> Tuple[bool, str]:
     """测试 CPA 连接（不走代理）"""
     if not api_url:

--- a/platforms/chatgpt/plugin.py
+++ b/platforms/chatgpt/plugin.py
@@ -161,6 +161,11 @@ class ChatGPTPlatform(BasePlatform):
                  {"key": "api_url", "label": "TM API URL", "type": "text"},
                  {"key": "api_key", "label": "TM API Key", "type": "text"},
              ]},
+            {"id": "upload_codex_proxy", "label": "上传 CodexProxy",
+             "params": [
+                 {"key": "api_url", "label": "API URL", "type": "text"},
+                 {"key": "api_key", "label": "Admin Key", "type": "text"},
+             ]},
         ]
 
     def execute_action(self, action_id: str, account: Account, params: dict) -> dict:
@@ -207,6 +212,12 @@ class ChatGPTPlatform(BasePlatform):
             from platforms.chatgpt.cpa_upload import upload_to_team_manager
             ok, msg = upload_to_team_manager(a, api_url=params.get("api_url"),
                                              api_key=params.get("api_key"))
+            return {"ok": ok, "data": msg}
+
+        elif action_id == "upload_codex_proxy":
+            from platforms.chatgpt.cpa_upload import upload_to_codex_proxy
+            ok, msg = upload_to_codex_proxy(a, api_url=params.get("api_url"),
+                                            api_key=params.get("api_key"))
             return {"ok": ok, "data": msg}
 
         raise NotImplementedError(f"未知操作: {action_id}")

--- a/services/external_sync.py
+++ b/services/external_sync.py
@@ -30,6 +30,27 @@ def sync_account(account) -> list[dict[str, Any]]:
             ok, msg = upload_to_cpa(generate_token_json(a))
             results.append({"name": "CPA", "ok": ok, "msg": msg})
 
+        codex_proxy_url = str(config_store.get("codex_proxy_url", "") or "").strip()
+        if codex_proxy_url:
+            upload_type = str(config_store.get("codex_proxy_upload_type", "at") or "at").strip().lower()
+            extra = account.extra or {}
+
+            class _CP:
+                pass
+
+            cp = _CP()
+            cp.access_token = extra.get("access_token") or account.token
+            cp.refresh_token = extra.get("refresh_token", "")
+
+            if upload_type == "rt":
+                from platforms.chatgpt.cpa_upload import upload_to_codex_proxy
+                ok, msg = upload_to_codex_proxy(cp)
+                results.append({"name": "CodexProxy(RT)", "ok": ok, "msg": msg})
+            else:
+                from platforms.chatgpt.cpa_upload import upload_at_to_codex_proxy
+                ok, msg = upload_at_to_codex_proxy(cp)
+                results.append({"name": "CodexProxy(AT)", "ok": ok, "msg": msg})
+
     elif platform == "grok":
         grok2api_url = str(config_store.get("grok2api_url", "") or "").strip()
         if grok2api_url:


### PR DESCRIPTION
## 功能说明

注册机使用 V2 流程注册时无法获取 refresh_token，本 PR 新增 Access Token 上传方式，并完善 CodexProxy 集成。

## 主要改动

- **cpa_upload.py**: 新增 upload_at_to_codex_proxy()，走 /api/admin/accounts/at 接口上传 AT
- **cpa_upload.py**: 新增 upload_to_codex_proxy()，走 /api/admin/accounts 接口上传 RT
- **plugin.py**: 添加 upload_codex_proxy action（手动触发）
- **external_sync.py**: 注册成功后自动上传到 CodexProxy，由 codex_proxy_upload_type 配置决定使用 AT 或 RT
- **Settings.tsx**: CodexProxy 配置区新增上传类型下拉（AT 推荐 / RT）
- **Accounts.tsx**: 账号列表和详情弹窗显示 refresh_token
- **api/config.py**: 将 codex_proxy_url / codex_proxy_key / codex_proxy_upload_type 加入配置白名单