### PR TITLE
feat: add chatgpt cpa backfill flow

### DIFF
--- a/api/actions.py
+++ b/api/actions.py
@@ -52,6 +52,17 @@ def execute_action(
 
     try:
         result = instance.execute_action(action_id, account, body.params)
+        if platform == "chatgpt" and action_id == "upload_cpa":
+            from services.chatgpt_sync import update_account_model_cpa_sync
+
+            sync_msg = result.get("data") or result.get("error") or ""
+            update_account_model_cpa_sync(
+                acc_model,
+                bool(result.get("ok")),
+                str(sync_msg),
+                session=session,
+                commit=False,
+            )
         # 若操作返回了新 token，更新数据库
         if result.get("ok") and result.get("data", {}) and isinstance(result["data"], dict):
             data = result["data"]
@@ -67,7 +78,7 @@ def execute_action(
                 from datetime import datetime, timezone
                 acc_model.updated_at = datetime.now(timezone.utc)
                 session.add(acc_model)
-                session.commit()
+        session.commit()
         return result
     except NotImplementedError as e:
         raise HTTPException(400, str(e))

--- a/api/integrations.py
+++ b/api/integrations.py
@@ -9,12 +9,17 @@ from sqlmodel import Session, select
 from core.base_platform import Account, AccountStatus
 from core.db import AccountModel, engine
 from services.external_apps import install, list_status, start, start_all, stop, stop_all
+from services.chatgpt_sync import has_cpa_upload_success, upload_account_model_to_cpa
 
 router = APIRouter(prefix="/integrations", tags=["integrations"])
 
 
 class BackfillRequest(BaseModel):
     platforms: list[str] = Field(default_factory=lambda: ["grok", "kiro"])
+    account_ids: list[int] = Field(default_factory=list)
+    pending_only: bool = False
+    status: Optional[str] = None
+    email: Optional[str] = None
 
 
 def _to_account(model: AccountModel) -> Account:
@@ -65,58 +70,79 @@ def backfill_integrations(body: BackfillRequest):
     summary = {"total": 0, "success": 0, "failed": 0, "items": []}
     targets = set(body.platforms or [])
 
-    if "grok" in targets:
-        from services.grok2api_runtime import ensure_grok2api_ready
-
-        ok, msg = ensure_grok2api_ready()
-        if not ok:
-            return {
-                "total": 0,
-                "success": 0,
-                "failed": 0,
-                "items": [{"platform": "grok", "email": "", "results": [{"name": "grok2api", "ok": False, "msg": msg}]}],
-            }
-
     with Session(engine) as s:
-        rows = s.exec(
-            select(AccountModel).where(AccountModel.platform.in_(targets))
-        ).all()
+        q = select(AccountModel)
+        if body.account_ids:
+            q = q.where(AccountModel.id.in_(body.account_ids))
+            if targets:
+                q = q.where(AccountModel.platform.in_(targets))
+        elif targets:
+            q = q.where(AccountModel.platform.in_(targets))
+        else:
+            return summary
 
-    for row in rows:
-        item = {"platform": row.platform, "email": row.email, "results": []}
-        try:
-            account = _to_account(row)
-            results = []
-            if row.platform == "grok":
-                from core.config_store import config_store
-                from platforms.grok.grok2api_upload import upload_to_grok2api
+        if body.status:
+            q = q.where(AccountModel.status == body.status)
+        if body.email:
+            q = q.where(AccountModel.email.contains(body.email))
 
-                api_url = str(config_store.get("grok2api_url", "") or "").strip() or "http://127.0.0.1:8011"
-                app_key = str(config_store.get("grok2api_app_key", "") or "").strip() or "grok2api"
-                ok, msg = upload_to_grok2api(account, api_url=api_url, app_key=app_key)
-                results.append({"name": "grok2api", "ok": ok, "msg": msg})
+        rows = s.exec(q).all()
+        if body.pending_only:
+            rows = [row for row in rows if row.platform != "chatgpt" or not has_cpa_upload_success(row)]
 
-            elif row.platform == "kiro":
-                from core.config_store import config_store
-                from platforms.kiro.account_manager_upload import upload_to_kiro_manager
+        if any(row.platform == "grok" for row in rows):
+            from services.grok2api_runtime import ensure_grok2api_ready
 
-                configured_path = str(config_store.get("kiro_manager_path", "") or "").strip() or None
-                ok, msg = upload_to_kiro_manager(account, path=configured_path)
-                results.append({"name": "Kiro Manager", "ok": ok, "msg": msg})
+            ok, msg = ensure_grok2api_ready()
+            if not ok:
+                return {
+                    "total": 0,
+                    "success": 0,
+                    "failed": 0,
+                    "items": [{"platform": "grok", "email": "", "results": [{"name": "grok2api", "ok": False, "msg": msg}]}],
+                }
 
-            if not results:
-                item["results"].append({"name": "skip", "ok": False, "msg": "未配置对应导入目标"})
-                summary["failed"] += 1
-            else:
-                item["results"] = results
-                if all(r.get("ok") for r in results):
-                    summary["success"] += 1
-                else:
+        for row in rows:
+            item = {"platform": row.platform, "email": row.email, "results": []}
+            try:
+                results = []
+                if row.platform == "chatgpt":
+                    ok, msg = upload_account_model_to_cpa(row, session=s, commit=True)
+                    results.append({"name": "CPA", "ok": ok, "msg": msg})
+
+                elif row.platform == "grok":
+                    from core.config_store import config_store
+                    from platforms.grok.grok2api_upload import upload_to_grok2api
+
+                    account = _to_account(row)
+                    api_url = str(config_store.get("grok2api_url", "") or "").strip() or "http://127.0.0.1:8011"
+                    app_key = str(config_store.get("grok2api_app_key", "") or "").strip() or "grok2api"
+                    ok, msg = upload_to_grok2api(account, api_url=api_url, app_key=app_key)
+                    results.append({"name": "grok2api", "ok": ok, "msg": msg})
+
+                elif row.platform == "kiro":
+                    from core.config_store import config_store
+                    from platforms.kiro.account_manager_upload import upload_to_kiro_manager
+
+                    account = _to_account(row)
+                    configured_path = str(config_store.get("kiro_manager_path", "") or "").strip() or None
+                    ok, msg = upload_to_kiro_manager(account, path=configured_path)
+                    results.append({"name": "Kiro Manager", "ok": ok, "msg": msg})
+
+                if not results:
+                    item["results"].append({"name": "skip", "ok": False, "msg": "未配置对应导入目标"})
                     summary["failed"] += 1
-        except Exception as e:
-            item["results"].append({"name": "error", "ok": False, "msg": str(e)})
-            summary["failed"] += 1
-        summary["items"].append(item)
-        summary["total"] += 1
+                else:
+                    item["results"] = results
+                    if all(r.get("ok") for r in results):
+                        summary["success"] += 1
+                    else:
+                        summary["failed"] += 1
+            except Exception as e:
+                s.rollback()
+                item["results"].append({"name": "error", "ok": False, "msg": str(e)})
+                summary["failed"] += 1
+            summary["items"].append(item)
+            summary["total"] += 1
 
     return summary

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -168,11 +168,11 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
                             account.extra.setdefault("luckmail_domain", merged_extra.get("luckmail_domain"))
                         if merged_extra.get("luckmail_base_url"):
                             account.extra.setdefault("luckmail_base_url", merged_extra.get("luckmail_base_url"))
-                save_account(account)
+                saved_account = save_account(account)
                 if _proxy: proxy_pool.report_success(_proxy)
                 _log(task_id, f"✓ 注册成功: {account.email}")
                 _save_task_log(req.platform, account.email, "success")
-                _auto_upload_integrations(task_id, account)
+                _auto_upload_integrations(task_id, saved_account or account)
                 cashier_url = (account.extra or {}).get("cashier_url", "")
                 if cashier_url:
                     _log(task_id, f"  [升级链接] {cashier_url}")

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -39,6 +39,29 @@ const STATUS_COLORS: Record<string, string> = {
   invalid: 'error',
 }
 
+function parseExtraJson(raw: string | undefined) {
+  if (!raw) return {}
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+function normalizeAccount(account: any) {
+  const extra = parseExtraJson(account.extra_json)
+  const syncStatuses = extra.sync_statuses && typeof extra.sync_statuses === 'object' ? extra.sync_statuses : {}
+  const cpaSync = syncStatuses.cpa && typeof syncStatuses.cpa === 'object' ? syncStatuses.cpa : {}
+  return { ...account, extra, cpaSync }
+}
+
+function formatSyncTime(value?: string) {
+  if (!value) return ''
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString()
+}
+
 function LogPanel({ taskId, onDone }: { taskId: string; onDone: () => void }) {
   const [lines, setLines] = useState<string[]>([])
   const [done, setDone] = useState(false)
@@ -186,6 +209,7 @@ export default function Accounts() {
   const [importLoading, setImportLoading] = useState(false)
   const [taskId, setTaskId] = useState<string | null>(null)
   const [registerLoading, setRegisterLoading] = useState(false)
+  const [cpaSyncLoading, setCpaSyncLoading] = useState<'pending' | 'selected' | ''>('')
 
   useEffect(() => {
     if (platform) setCurrentPlatform(platform)
@@ -198,7 +222,7 @@ export default function Accounts() {
       if (search) params.set('email', search)
       if (filterStatus) params.set('status', filterStatus)
       const data = await apiFetch(`/accounts?${params}`)
-      setAccounts(data.items)
+      setAccounts((data.items || []).map(normalizeAccount))
       setTotal(data.total)
     } finally {
       setLoading(false)
@@ -331,6 +355,96 @@ export default function Accounts() {
     load()
   }
 
+  const showCpaSyncResult = (title: string, result: any) => {
+    const lines = (result.items || [])
+      .flatMap((item: any) =>
+        (item.results || []).map((syncResult: any) => ({
+          email: item.email,
+          platform: item.platform,
+          ok: Boolean(syncResult.ok),
+          name: syncResult.name || 'CPA',
+          msg: syncResult.msg || '',
+        })),
+      )
+      .filter((item: any) => !item.ok)
+      .map((item: any) => `[${item.platform}] ${item.email || '-'} / ${item.name}: ${item.msg || '失败'}`)
+
+    if (lines.length === 0) return
+
+    Modal.info({
+      title,
+      width: 760,
+      content: (
+        <pre
+          style={{
+            margin: 0,
+            maxHeight: 360,
+            overflow: 'auto',
+            padding: 12,
+            borderRadius: 8,
+            background: 'rgba(127,127,127,0.08)',
+            fontSize: 12,
+            lineHeight: 1.5,
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-word',
+          }}
+        >
+          {lines.join('\n')}
+        </pre>
+      ),
+    })
+  }
+
+  const handleCpaBackfill = async (mode: 'pending' | 'selected') => {
+    if (currentPlatform !== 'chatgpt') return
+
+    const body: Record<string, unknown> = {
+      platforms: ['chatgpt'],
+    }
+
+    if (mode === 'selected') {
+      const accountIds = Array.from(selectedRowKeys)
+        .map((value) => Number(value))
+        .filter((value) => Number.isInteger(value) && value > 0)
+
+      if (accountIds.length === 0) {
+        message.warning('请先选择要上传的账号')
+        return
+      }
+      body.account_ids = accountIds
+    } else {
+      body.pending_only = true
+      if (filterStatus) body.status = filterStatus
+      if (search) body.email = search
+    }
+
+    setCpaSyncLoading(mode)
+    try {
+      const result = await apiFetch('/integrations/backfill', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+
+      const actionLabel = mode === 'selected' ? '所选账号 CPA 上传' : '未上传账号 CPA 补传'
+      if (!result.total) {
+        message.info('没有可处理的账号')
+      } else if (!result.failed) {
+        message.success(`${actionLabel}完成：成功 ${result.success} / ${result.total}`)
+      } else if (!result.success) {
+        message.error(`${actionLabel}失败：成功 ${result.success} / ${result.total}`)
+      } else {
+        message.warning(`${actionLabel}部分完成：成功 ${result.success} / ${result.total}`)
+      }
+
+      showCpaSyncResult(`${actionLabel}结果`, result)
+      await load()
+    } catch (e: any) {
+      message.error(`CPA 上传失败: ${e.message}`)
+    } finally {
+      setCpaSyncLoading('')
+    }
+  }
+
   const columns: any[] = [
     {
       title: '邮箱',
@@ -404,6 +518,37 @@ export default function Accounts() {
     },
   ]
 
+  if (currentPlatform === 'chatgpt') {
+    columns.splice(4, 0, {
+      title: 'CPA',
+      key: 'cpa_sync',
+      render: (_: any, record: any) => {
+        const sync = record.cpaSync || {}
+        const uploaded = Boolean(sync.uploaded || sync.uploaded_at)
+        const attempted = Boolean(sync.last_attempt_at)
+        const color = uploaded ? 'success' : attempted ? 'error' : 'default'
+        const label = uploaded ? '已上传' : attempted ? '最近失败' : '未上传'
+        const time = uploaded ? sync.uploaded_at : sync.last_attempt_at
+
+        return (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4, minWidth: 140 }}>
+            <Tag color={color}>{label}</Tag>
+            {time ? (
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                {formatSyncTime(time)}
+              </Text>
+            ) : null}
+            {sync.last_message ? (
+              <Text type="secondary" ellipsis={{ tooltip: sync.last_message }} style={{ maxWidth: 220, fontSize: 12 }}>
+                {sync.last_message}
+              </Text>
+            ) : null}
+          </div>
+        )
+      },
+    })
+  }
+
   return (
     <div>
       <div style={{ marginBottom: 16, display: 'flex', justifyContent: 'space-between', flexWrap: 'wrap', gap: 8 }}>
@@ -433,6 +578,26 @@ export default function Accounts() {
           )}
         </Space>
         <Space>
+          {currentPlatform === 'chatgpt' && selectedRowKeys.length > 0 && (
+            <Popconfirm
+              title={`确认上传选中的 ${selectedRowKeys.length} 个账号到 CPA？`}
+              onConfirm={() => handleCpaBackfill('selected')}
+            >
+              <Button loading={cpaSyncLoading === 'selected'} icon={<UploadOutlined />}>
+                上传所选 CPA
+              </Button>
+            </Popconfirm>
+          )}
+          {currentPlatform === 'chatgpt' && (
+            <Popconfirm
+              title="确认补传当前筛选范围内尚未成功上传 CPA 的账号？"
+              onConfirm={() => handleCpaBackfill('pending')}
+            >
+              <Button loading={cpaSyncLoading === 'pending'} icon={<UploadOutlined />} disabled={total === 0}>
+                补传未上传 CPA
+              </Button>
+            </Popconfirm>
+          )}
           {selectedRowKeys.length > 0 && (
             <Popconfirm title={`确认删除选中的 ${selectedRowKeys.length} 个账号？`} onConfirm={handleBatchDelete}>
               <Button danger icon={<DeleteOutlined />}>删除 {selectedRowKeys.length} 个</Button>

--- a/services/chatgpt_sync.py
+++ b/services/chatgpt_sync.py
@@ -1,0 +1,143 @@
+"""ChatGPT 账号与 CPA 的同步辅助逻辑。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlmodel import Session
+
+from core.db import AccountModel, engine
+
+CPA_SYNC_NAME = "cpa"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utcnow_iso() -> str:
+    return _utcnow().isoformat()
+
+
+def _get_account_extra(account: Any) -> dict[str, Any]:
+    if hasattr(account, "get_extra"):
+        try:
+            extra = account.get_extra()
+            if isinstance(extra, dict):
+                return extra
+        except Exception:
+            pass
+    extra = getattr(account, "extra", {})
+    return extra if isinstance(extra, dict) else {}
+
+
+def get_cpa_sync_state(extra_or_account: Any) -> dict[str, Any]:
+    extra = extra_or_account if isinstance(extra_or_account, dict) else _get_account_extra(extra_or_account)
+    sync_statuses = extra.get("sync_statuses", {})
+    if not isinstance(sync_statuses, dict):
+        return {}
+    state = sync_statuses.get(CPA_SYNC_NAME, {})
+    return state if isinstance(state, dict) else {}
+
+
+def has_cpa_upload_success(extra_or_account: Any) -> bool:
+    state = get_cpa_sync_state(extra_or_account)
+    return bool(state.get("uploaded") or state.get("uploaded_at"))
+
+
+def record_cpa_sync_result(extra: dict[str, Any], ok: bool, msg: str) -> dict[str, Any]:
+    sync_statuses = extra.get("sync_statuses")
+    if not isinstance(sync_statuses, dict):
+        sync_statuses = {}
+
+    state = sync_statuses.get(CPA_SYNC_NAME)
+    if not isinstance(state, dict):
+        state = {}
+
+    now = _utcnow_iso()
+    state["last_attempt_ok"] = bool(ok)
+    state["last_message"] = msg
+    state["last_attempt_at"] = now
+    state["uploaded"] = bool(state.get("uploaded")) or bool(ok)
+    if ok:
+        state["uploaded_at"] = now
+
+    sync_statuses[CPA_SYNC_NAME] = state
+    extra["sync_statuses"] = sync_statuses
+    return state
+
+
+def build_chatgpt_sync_account(account: Any):
+    extra = _get_account_extra(account)
+
+    class _SyncAccount:
+        pass
+
+    obj = _SyncAccount()
+    obj.email = getattr(account, "email", "")
+    obj.access_token = extra.get("access_token") or getattr(account, "token", "")
+    obj.refresh_token = extra.get("refresh_token", "")
+    obj.id_token = extra.get("id_token", "")
+    obj.session_token = extra.get("session_token", "")
+    obj.client_id = extra.get("client_id", "app_EMoamEEZ73f0CkXaXp7hrann")
+    obj.cookies = extra.get("cookies", "")
+    return obj
+
+
+def upload_chatgpt_account_to_cpa(account: Any, api_url: str | None = None, api_key: str | None = None) -> tuple[bool, str]:
+    try:
+        sync_account = build_chatgpt_sync_account(account)
+        if not getattr(sync_account, "access_token", ""):
+            return False, "账号缺少 access_token"
+
+        from platforms.chatgpt.cpa_upload import generate_token_json, upload_to_cpa
+
+        token_data = generate_token_json(sync_account)
+        return upload_to_cpa(token_data, api_url=api_url, api_key=api_key)
+    except Exception as exc:
+        return False, f"上传异常: {exc}"
+
+
+def update_account_model_cpa_sync(
+    account: AccountModel,
+    ok: bool,
+    msg: str,
+    session: Session | None = None,
+    commit: bool = True,
+) -> dict[str, Any]:
+    extra = account.get_extra()
+    state = record_cpa_sync_result(extra, ok, msg)
+    account.set_extra(extra)
+    account.updated_at = _utcnow()
+    if session is not None:
+        session.add(account)
+        if commit:
+            session.commit()
+            session.refresh(account)
+    return state
+
+
+def persist_cpa_sync_result(account: Any, ok: bool, msg: str) -> None:
+    if isinstance(account, AccountModel) and account.id is not None:
+        with Session(engine) as session:
+            row = session.get(AccountModel, account.id)
+            if row:
+                update_account_model_cpa_sync(row, ok, msg, session=session, commit=True)
+                return
+
+    extra = getattr(account, "extra", None)
+    if isinstance(extra, dict):
+        record_cpa_sync_result(extra, ok, msg)
+
+
+def upload_account_model_to_cpa(
+    account: AccountModel,
+    session: Session | None = None,
+    api_url: str | None = None,
+    api_key: str | None = None,
+    commit: bool = True,
+) -> tuple[bool, str]:
+    ok, msg = upload_chatgpt_account_to_cpa(account, api_url=api_url, api_key=api_key)
+    update_account_model_cpa_sync(account, ok, msg, session=session, commit=commit)
+    return ok, msg

--- a/services/external_sync.py
+++ b/services/external_sync.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from services.chatgpt_sync import persist_cpa_sync_result, upload_chatgpt_account_to_cpa
+
 
 def sync_account(account) -> list[dict[str, Any]]:
     """根据平台将账号同步到外部系统。"""
@@ -15,19 +17,8 @@ def sync_account(account) -> list[dict[str, Any]]:
     if platform == "chatgpt":
         cpa_url = config_store.get("cpa_api_url", "")
         if cpa_url:
-            from platforms.chatgpt.cpa_upload import generate_token_json, upload_to_cpa
-
-            class _A:
-                pass
-
-            a = _A()
-            a.email = account.email
-            extra = account.extra or {}
-            a.access_token = extra.get("access_token") or account.token
-            a.refresh_token = extra.get("refresh_token", "")
-            a.id_token = extra.get("id_token", "")
-
-            ok, msg = upload_to_cpa(generate_token_json(a))
+            ok, msg = upload_chatgpt_account_to_cpa(account)
+            persist_cpa_sync_result(account, ok, msg)
             results.append({"name": "CPA", "ok": ok, "msg": msg})
 
     elif platform == "grok":


### PR DESCRIPTION
  ## Summary
  - add ChatGPT CPA backfill support for historical accounts
  - persist CPA upload status/result in account extra data
  - add frontend actions for "upload selected CPA" and "backfill pending CPA"
  - show CPA sync status in ChatGPT accounts page

  ## Problem
  Previously, if CPA configuration was wrong during registration, accounts could be created successfully but never
  uploaded later in batch from the frontend.

  ## Verification
  - python -m compileall api services core
  - npx tsc -b
  - npm run build