### PR TITLE
feat: 对齐 _ext_targets 挂载路径并补充插件依赖环境与插件端口映射

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,14 @@ WORKDIR /app
 COPY requirements.txt ./
 COPY scripts/install_camoufox.py /tmp/install_camoufox.py
 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl ca-certificates \
+    && curl -fsSL https://go.dev/dl/go1.24.2.linux-amd64.tar.gz | tar -C /usr/local -xz \
+    && curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/usr/local/go/bin:/root/.local/bin:${PATH}"
+
 RUN pip install --upgrade pip \
     && pip install -r requirements.txt \
     && installed=0 \
@@ -53,11 +61,14 @@ RUN pip install --upgrade pip \
 COPY . .
 COPY --from=frontend-builder /app/static /app/static
 
-RUN chmod +x /app/docker/entrypoint.sh \
-    && mkdir -p /runtime /runtime/logs /runtime/smstome_used /app/_ext_targets
+RUN apt-get update && apt-get install -y --no-install-recommends dos2unix git iproute2 procps \
+    && dos2unix /app/docker/entrypoint.sh \
+    && chmod +x /app/docker/entrypoint.sh \
+    && mkdir -p /runtime /runtime/logs /runtime/smstome_used /_ext_targets \
+    && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8000 8889
 
-VOLUME ["/runtime", "/app/_ext_targets"]
+VOLUME ["/runtime", "/_ext_targets"]
 
 ENTRYPOINT ["/app/docker/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,11 @@ services:
       SOLVER_BROWSER_TYPE: ${SOLVER_BROWSER_TYPE:-camoufox}
     ports:
       - "8000:8000"
-      - "8889:8889"
+      - "127.0.0.1:8889:8889"
+      - "8317:8317"
+      - "8011:8011"
     volumes:
-      - ./data:/runtime
-      - ./_ext_targets:/app/_ext_targets
+      - /opt/kom-any-auto-register/data:/runtime
+      - /opt/kom-any-auto-register/_ext_targets:/_ext_targets
+      - /opt/kom-any-auto-register/external_logs:/app/services/external_logs
     shm_size: "1gb"


### PR DESCRIPTION
对齐插件扩展目录挂载路径，统一为 /_ext_targets，避免容器内路径不一致导致插件资源读取异常。
在镜像中补全 CPA 等插件运行依赖（如 git、curl、dos2unix、iproute2、procps，并补充 go 与 uv 可用环境）。
更新容器端口映射，新增插件相关端口与日志目录挂载，便于外部服务访问