### PR TITLE
feat(outlook): display imported outlook account count in settings

### DIFF
--- a/api/outlook.py
+++ b/api/outlook.py
@@ -27,6 +27,15 @@ class OutlookBatchImportResponse(BaseModel):
     errors: List[str]
 
 
+@router.get("/count")
+def get_outlook_count():
+    """返回 Outlook 邮箱总数"""
+    with Session(engine) as session:
+        from sqlmodel import func
+        count = session.exec(select(func.count()).select_from(OutlookAccountModel)).one()
+        return {"count": count}
+
+
 @router.post("/batch-import", response_model=OutlookBatchImportResponse)
 def batch_import_outlook(request: OutlookBatchImportRequest):
     """

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1353,6 +1353,16 @@ function OutlookImportSection() {
   const [value, setValue] = useState('')
   const [loading, setLoading] = useState(false)
   const [result, setResult] = useState<any | null>(null)
+  const [count, setCount] = useState<number | null>(null)
+
+  const fetchCount = async () => {
+    try {
+      const res = await apiFetch('/outlook/count')
+      setCount(res.count)
+    } catch {}
+  }
+
+  useEffect(() => { fetchCount() }, [])
 
   const handleSubmit = async () => {
     const payload = String(value || '').trim()
@@ -1368,6 +1378,7 @@ function OutlookImportSection() {
       })
       setResult(res)
       msg.success(`导入完成：成功 ${res.success} / 失败 ${res.failed}`)
+      fetchCount()
     } catch (e: any) {
       msg.error(e?.message || '导入失败')
       setResult({ error: e?.message || String(e) })
@@ -1378,7 +1389,7 @@ function OutlookImportSection() {
 
   return (
     <Card
-      title="Outlook 批量导入"
+      title={<>Outlook 批量导入{count !== null && <span style={{ fontSize: 13, fontWeight: 400, color: '#7a8ba3', marginLeft: 8 }}>已导入 {count} 个</span>}</>}
       extra={<span style={{ fontSize: 12, color: '#7a8ba3' }}>每行格式：邮箱----密码 或 邮箱----密码----client_id----refresh_token</span>}
       style={{ marginBottom: 16 }}
     >


### PR DESCRIPTION
## Summary
- 后端新增 `GET /api/outlook/count` 接口，返回 Outlook 邮箱总数
- 前端设置页「Outlook 批量导入」卡片标题旁显示已导入数量，导入成功后自动刷新

## Test plan
- [ ] 打开设置页 → 邮箱 tab，确认「Outlook 批量导入」标题旁显示正确数量
- [ ] 导入新的 Outlook 账号后，数量自动更新
- [ ] 数据库为空时不显示数量文字