### PR TITLE
fix(scheduler): prevent immediate task execution on startup

### DIFF
--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -21,8 +21,12 @@ class Scheduler:
         if self._running:
             return
         self._running = True
-        self._last_trial_check_at = 0.0
-        self._last_cpa_maintenance_at = 0.0
+        
+        now = time.time()
+        # 将上次执行时间设为当前时间，避免应用一启动就瞬间触发定时任务（如 CPA 自动注册）
+        self._last_trial_check_at = now
+        self._last_cpa_maintenance_at = now
+
         self._thread = threading.Thread(target=self._loop, daemon=True)
         self._thread.start()
         print("[Scheduler] 已启动")


### PR DESCRIPTION
修复 scheduler 在启动时立即触发定时任务（如 CPA 自动补足）的 Bug。原代码中将初始化时间设为 0.0，导致应用只要启用了相关自动任务选项，便会在启动时立刻无视定时间隔将其跑起来。这经常导致启动服务时的『突发全量任务涌入』。本 PR 将初始上次维护时间修正为进程启动的实际时间 time.time()，让 Scheduler 能够正常的遵守 interval 间隔。