### PR TITLE
feat: 增强恢复能力并提升 ChatGPT 取 token 成功率

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -6,6 +6,7 @@ from services.mail_imports import MailImportExecuteRequest, MailImportSnapshotRe
 router = APIRouter(prefix="/config", tags=["config"])
 
 CONFIG_KEYS = [
+    "proxy_auto_disable_enabled",
     "email_domain_rule_enabled",
     "email_domain_level_count",
     "laoudo_auth",
@@ -119,6 +120,8 @@ class AppleMailImportRequest(BaseModel):
 @router.get("")
 def get_config():
     all_cfg = config_store.get_all()
+    if not str(all_cfg.get("proxy_auto_disable_enabled", "") or "").strip():
+        all_cfg["proxy_auto_disable_enabled"] = "1"
     if all_cfg.get("mail_provider") == "outlook":
         all_cfg["mail_provider"] = "microsoft"
     if not all_cfg.get("mail_provider"):
@@ -158,6 +161,11 @@ def update_config(body: ConfigUpdate):
     if "email_domain_rule_enabled" in safe:
         enabled = str(safe.get("email_domain_rule_enabled", "")).strip().lower()
         safe["email_domain_rule_enabled"] = (
+            "1" if enabled in {"1", "true", "yes", "on"} else "0"
+        )
+    if "proxy_auto_disable_enabled" in safe:
+        enabled = str(safe.get("proxy_auto_disable_enabled", "")).strip().lower()
+        safe["proxy_auto_disable_enabled"] = (
             "1" if enabled in {"1", "true", "yes", "on"} else "0"
         )
     if "email_domain_level_count" in safe:

--- a/api/mail_imports.py
+++ b/api/mail_imports.py
@@ -7,6 +7,14 @@ from services.mail_imports import (
     MailImportSnapshotRequest,
     mail_import_registry,
 )
+from services.mail_imports.recovery_pool import (
+    get_microsoft_recovery_pool,
+    restore_microsoft_recovery_item,
+)
+from services.mail_imports.schemas import (
+    MailRecoveryPoolRequest,
+    MailRecoveryPoolRestoreRequest,
+)
 
 router = APIRouter(prefix="/mail-imports", tags=["mail-imports"])
 
@@ -32,6 +40,38 @@ def get_mail_import_snapshot(
             preview_limit=preview_limit,
         )
         return strategy.get_snapshot(request)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/recovery-pool")
+def get_recovery_pool_snapshot(
+    mailbox_type: str = Query(default="all"),
+    status: str = Query(default="all"),
+    search: str = "",
+    limit: int = 100,
+):
+    try:
+        request = MailRecoveryPoolRequest(
+            mailbox_type=mailbox_type,
+            status=status,
+            search=search,
+            limit=limit,
+        )
+        return get_microsoft_recovery_pool(request)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.post("/recovery-pool/restore")
+def restore_recovery_pool_item(body: MailRecoveryPoolRestoreRequest):
+    try:
+        item = restore_microsoft_recovery_item(body.id)
+        return {"ok": True, "item": item}
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except RuntimeError as exc:

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -8,9 +8,12 @@ from core.db import TaskLog, engine
 from core.task_runtime import (
     AttemptOutcome,
     AttemptResult,
+    build_http_400_pause_reason,
+    PauseTaskRequested,
     RegisterTaskStore,
     SkipCurrentAttemptRequested,
     StopTaskRequested,
+    should_auto_pause_on_http_400,
 )
 import time, json, asyncio, threading, logging, sys
 
@@ -32,6 +35,7 @@ class RegisterTaskRequest(BaseModel):
     count: int = 1
     concurrency: int = 1
     register_delay_seconds: float = 0
+    auto_pause_on_http_400: bool = True
     proxy: Optional[str] = None
     executor_type: str = "protocol"
     captcha_solver: str = "yescaptcha"
@@ -50,7 +54,7 @@ def _ensure_task_exists(task_id: str) -> None:
 def _ensure_task_mutable(task_id: str) -> None:
     _ensure_task_exists(task_id)
     snapshot = _task_store.snapshot(task_id)
-    if snapshot.get("status") in {"done", "failed", "stopped"}:
+    if snapshot.get("status") in {"done", "failed", "stopped", "paused"}:
         raise HTTPException(409, "任务已结束，无法再执行控制操作")
 
 
@@ -222,6 +226,20 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
             time.sleep(chunk)
             remaining -= chunk
 
+    def _auto_pause_for_error(error: Exception) -> bool:
+        if not bool(req.auto_pause_on_http_400):
+            return False
+
+        message = str(error or "").strip()
+        if not should_auto_pause_on_http_400(message):
+            return False
+
+        reason = build_http_400_pause_reason(message)
+        is_new_pause = control.request_pause(reason)
+        if is_new_pause:
+            _log(task_id, f"[PAUSE] {reason}")
+        return True
+
     try:
         PlatformCls = get(req.platform)
 
@@ -374,9 +392,13 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
             except StopTaskRequested as e:
                 _log(task_id, f"[STOP] {e}")
                 return AttemptResult.stopped(str(e))
+            except PauseTaskRequested as e:
+                _log(task_id, f"[PAUSE] {e}")
+                return AttemptResult.paused(str(e))
             except Exception as e:
                 if _proxy and proxy_pool is not None:
                     proxy_pool.report_fail(_proxy)
+                _auto_pause_for_error(e)
                 _log(task_id, f"[FAIL] 注册失败: {e}")
                 _save_task_log(
                     req.platform,
@@ -392,6 +414,7 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
 
         max_workers = min(req.concurrency, req.count, 5)
         stopped = False
+        paused = False
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             futures = [pool.submit(_do_one, i) for i in range(req.count)]
             for f in as_completed(futures):
@@ -409,6 +432,8 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
                     skipped += 1
                 elif result.outcome == AttemptOutcome.STOPPED:
                     stopped = True
+                elif result.outcome == AttemptOutcome.PAUSED:
+                    paused = True
                 else:
                     errors.append(result.message)
                 _task_store.update_counters(
@@ -416,8 +441,14 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
                     success=success,
                     registered=success + skipped + len(errors),
                 )
-                if stopped or control.is_stop_requested():
-                    stopped = True
+                if (
+                    paused
+                    or stopped
+                    or control.is_pause_requested()
+                    or control.is_stop_requested()
+                ):
+                    paused = paused or control.is_pause_requested()
+                    stopped = stopped or control.is_stop_requested()
                     for pending in futures:
                         if pending is not f:
                             pending.cancel()
@@ -435,8 +466,20 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
         _task_store.cleanup()
         return
 
-    final_status = "stopped" if control.is_stop_requested() or stopped else "done"
-    if final_status == "stopped":
+    final_status = "done"
+    if control.is_pause_requested() or paused:
+        final_status = "paused"
+    elif control.is_stop_requested() or stopped:
+        final_status = "stopped"
+
+    if final_status == "paused":
+        summary = (
+            f"任务已暂停: 成功 {success} 个, 跳过 {skipped} 个, 失败 {len(errors)} 个"
+        )
+        pause_reason = control.pause_reason()
+        if pause_reason:
+            summary = f"{summary}，{pause_reason}"
+    elif final_status == "stopped":
         summary = (
             f"任务已停止: 成功 {success} 个, 跳过 {skipped} 个, 失败 {len(errors)} 个"
         )
@@ -450,6 +493,7 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
         registered=success + skipped + len(errors),
         skipped=skipped,
         errors=errors,
+        error=control.pause_reason() if final_status == "paused" else "",
     )
     _task_store.cleanup()
 
@@ -542,7 +586,7 @@ async def stream_logs(task_id: str, since: int = 0):
             while sent < len(logs):
                 yield f"data: {json.dumps({'line': logs[sent], **counters})}\n\n"
                 sent += 1
-            if status in ("done", "failed", "stopped"):
+            if status in ("done", "failed", "stopped", "paused"):
                 yield f"data: {json.dumps({'done': True, 'status': status, **counters})}\n\n"
                 break
             await asyncio.sleep(0.5)

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -12,7 +12,7 @@ from core.task_runtime import (
     SkipCurrentAttemptRequested,
     StopTaskRequested,
 )
-import time, json, asyncio, threading, logging
+import time, json, asyncio, threading, logging, sys
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 logger = logging.getLogger(__name__)
@@ -119,12 +119,48 @@ def has_active_register_task(
     return _task_store.has_active(platform=platform, source=source)
 
 
+def _write_console_entry(entry: str) -> None:
+    try:
+        print(entry)
+        return
+    except UnicodeEncodeError:
+        pass
+
+    stream = getattr(sys, "stdout", None)
+    if stream is None:
+        return
+
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    try:
+        safe_entry = entry.encode(encoding, errors="backslashreplace").decode(encoding)
+    except Exception:
+        safe_entry = entry.encode("ascii", errors="backslashreplace").decode("ascii")
+
+    try:
+        stream.write(f"{safe_entry}\n")
+    except UnicodeEncodeError:
+        try:
+            buffer = getattr(stream, "buffer", None)
+            if buffer is None:
+                return
+            buffer.write(safe_entry.encode(encoding, errors="replace") + b"\n")
+        except Exception:
+            return
+    except Exception:
+        return
+
+    try:
+        stream.flush()
+    except Exception:
+        return
+
+
 def _log(task_id: str, msg: str):
     """向任务追加一条日志"""
     ts = time.strftime("%H:%M:%S")
     entry = f"[{ts}] {msg}"
     _task_store.append_log(task_id, entry)
-    print(entry)
+    _write_console_entry(entry)
 
 
 def _save_task_log(
@@ -169,7 +205,9 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
     success = 0
     skipped = 0
     errors = []
+    workspace_success = 0
     start_gate_lock = threading.Lock()
+    workspace_progress_lock = threading.Lock()
     next_start_time = time.time()
 
     def _sleep_with_control(
@@ -201,7 +239,7 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
             )
 
         def _do_one(i: int):
-            nonlocal next_start_time
+            nonlocal next_start_time, workspace_success
             proxy_pool = None
             _proxy = None
             current_email = req.email or ""
@@ -307,6 +345,16 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
                 if _proxy:
                     proxy_pool.report_success(_proxy)
                 _log(task_id, f"[OK] 注册成功: {account.email}")
+                workspace_id = ""
+                if isinstance(account.extra, dict):
+                    workspace_id = str(account.extra.get("workspace_id") or "").strip()
+                if workspace_id:
+                    with workspace_progress_lock:
+                        workspace_success += 1
+                        _log(
+                            task_id,
+                            f"[ChatGPT] workspace\u8fdb\u5ea6: {workspace_success}/{req.count}",
+                        )
                 _save_task_log(req.platform, account.email, "success")
                 _auto_upload_integrations(task_id, saved_account or account)
                 cashier_url = (account.extra or {}).get("cashier_url", "")

--- a/core/base_mailbox.py
+++ b/core/base_mailbox.py
@@ -9,6 +9,7 @@ import time
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional, Any, Callable
 from .proxy_utils import build_requests_proxy_config
 
@@ -3162,6 +3163,7 @@ class OutlookImapMailboxBackend(OutlookMailboxBackend):
             for code in (kwargs.get("exclude_codes") or set())
             if str(code or "").strip()
         }
+        otp_sent_at = self.mailbox._otp_cutoff_timestamp(kwargs.get("otp_sent_at"))
         keyword_lower = str(keyword or "").strip().lower()
 
         def poll_once() -> Optional[str]:
@@ -3221,9 +3223,17 @@ class OutlookImapMailboxBackend(OutlookMailboxBackend):
                         msg = message_from_bytes(raw, policy=email_default_policy)
                         subject = self.mailbox._decode_header_value(msg.get("Subject", ""))
                         text = self.mailbox._extract_message_text(msg)
+                        message_ts = self.mailbox._parse_message_timestamp(
+                            msg.get("Date", ""),
+                        )
                         self.mailbox._log(
                             f"[微软邮箱][IMAP] folder={folder} 命中新邮件 subject={subject or '-'}"
                         )
+                        if otp_sent_at and message_ts and message_ts < otp_sent_at:
+                            self.mailbox._log(
+                                f"[微软邮箱][IMAP] folder={folder} 跳过旧邮件 Date={msg.get('Date', '') or '-'}"
+                            )
+                            continue
                         if keyword_lower and keyword_lower not in text.lower():
                             self.mailbox._log(
                                 f"[微软邮箱][IMAP] folder={folder} 跳过关键字不匹配邮件"
@@ -3299,6 +3309,7 @@ class OutlookGraphMailboxBackend(OutlookMailboxBackend):
             for code in (kwargs.get("exclude_codes") or set())
             if str(code or "").strip()
         }
+        otp_sent_at = self.mailbox._otp_cutoff_timestamp(kwargs.get("otp_sent_at"))
         keyword_lower = str(keyword or "").strip().lower()
 
         def poll_once() -> Optional[str]:
@@ -3327,9 +3338,17 @@ class OutlookGraphMailboxBackend(OutlookMailboxBackend):
                     for message in new_messages:
                         subject = str(message.get("subject") or "").strip()
                         text = self.mailbox._graph_message_text(message)
+                        message_ts = self.mailbox._parse_message_timestamp(
+                            message.get("receivedDateTime"),
+                        )
                         self.mailbox._log(
                             f"[微软邮箱][Graph] folder={folder} 命中新邮件 subject={subject or '-'}"
                         )
+                        if otp_sent_at and message_ts and message_ts < otp_sent_at:
+                            self.mailbox._log(
+                                f"[微软邮箱][Graph] folder={folder} 跳过旧邮件 receivedDateTime={message.get('receivedDateTime') or '-'}"
+                            )
+                            continue
                         if keyword_lower and keyword_lower not in text.lower():
                             self.mailbox._log(
                                 f"[微软邮箱][Graph] folder={folder} 跳过关键字不匹配邮件"
@@ -3344,6 +3363,9 @@ class OutlookGraphMailboxBackend(OutlookMailboxBackend):
                                     message_id=message_id,
                                 )
                                 text = self.mailbox._graph_message_text(detail)
+                                message_ts = message_ts or self.mailbox._parse_message_timestamp(
+                                    detail.get("receivedDateTime"),
+                                )
                                 code = self.mailbox._safe_extract(text, code_pattern)
                         if not code:
                             self.mailbox._log(
@@ -4061,6 +4083,41 @@ class OutlookMailbox(BaseMailbox):
             part for part in [subject, preview, body_content, unique_body_content] if part
         )
         return self._decode_raw_content(combined)
+
+    @staticmethod
+    def _parse_message_timestamp(*values) -> Optional[float]:
+        from email.utils import parsedate_to_datetime
+
+        for value in values:
+            if value in (None, ""):
+                continue
+            if isinstance(value, (int, float)):
+                numeric = float(value)
+                return numeric / 1000 if numeric > 10_000_000_000 else numeric
+            text = str(value).strip()
+            if not text:
+                continue
+            try:
+                numeric = float(text)
+                return numeric / 1000 if numeric > 10_000_000_000 else numeric
+            except (TypeError, ValueError):
+                pass
+            try:
+                return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+            except ValueError:
+                pass
+            try:
+                return parsedate_to_datetime(text).timestamp()
+            except (TypeError, ValueError, IndexError, OverflowError):
+                continue
+        return None
+
+    @staticmethod
+    def _otp_cutoff_timestamp(otp_sent_at: Any) -> Optional[float]:
+        parsed = OutlookMailbox._parse_message_timestamp(otp_sent_at)
+        if not parsed:
+            return None
+        return parsed - 2.0
 
     def _decode_header_value(self, value: str) -> str:
         from email.header import decode_header

--- a/core/base_mailbox.py
+++ b/core/base_mailbox.py
@@ -3428,9 +3428,44 @@ class OutlookMailbox(BaseMailbox):
         backend = str(value or "graph").strip().lower() or "graph"
         return backend if backend in {"graph", "imap"} else "graph"
 
+    @staticmethod
+    def _resolve_outlook_lease_id(account: MailboxAccount) -> int | None:
+        extra = getattr(account, "extra", None) or {}
+        raw_value = extra.get("outlook_lease_id")
+        try:
+            lease_id = int(raw_value)
+        except (TypeError, ValueError):
+            return None
+        return lease_id if lease_id > 0 else None
+
+    def _find_leased_account(self, session, account: MailboxAccount):
+        from sqlmodel import select
+        from core.db import OutlookAccountLeaseModel
+
+        lease_id = self._resolve_outlook_lease_id(account)
+        if lease_id is not None:
+            leased = session.get(OutlookAccountLeaseModel, lease_id)
+            if leased is not None:
+                return leased
+
+        email = str(getattr(account, "email", "") or "").strip()
+        if not email:
+            return None
+
+        return session.exec(
+            select(OutlookAccountLeaseModel).where(
+                OutlookAccountLeaseModel.email == email
+            )
+        ).first()
+
     def _pop_account(self) -> dict:
         from sqlmodel import Session, select
-        from core.db import engine, OutlookAccountModel
+        from core.db import (
+            OutlookAccountLeaseModel,
+            OutlookAccountModel,
+            _utcnow,
+            engine,
+        )
 
         with self._lock:
             with Session(engine) as session:
@@ -3445,12 +3480,51 @@ class OutlookMailbox(BaseMailbox):
                 if not account:
                     raise RuntimeError("微软邮箱账号池为空，请先在设置页批量导入")
 
+                now = _utcnow()
+                lease = session.exec(
+                    select(OutlookAccountLeaseModel).where(
+                        OutlookAccountLeaseModel.email == account.email
+                    )
+                ).first()
+                if lease:
+                    lease.password = account.password
+                    lease.client_id = account.client_id
+                    lease.refresh_token = account.refresh_token
+                    lease.source_account_id = account.id
+                    lease.task_attempt_id = str(
+                        getattr(self, "_task_attempt_token", "") or ""
+                    )
+                    lease.status = "leased"
+                    lease.last_error = ""
+                    lease.leased_at = now
+                    lease.last_failed_at = None
+                    lease.updated_at = now
+                    session.add(lease)
+                else:
+                    lease = OutlookAccountLeaseModel(
+                        email=account.email,
+                        password=account.password,
+                        client_id=account.client_id,
+                        refresh_token=account.refresh_token,
+                        source_account_id=account.id,
+                        task_attempt_id=str(
+                            getattr(self, "_task_attempt_token", "") or ""
+                        ),
+                        status="leased",
+                        leased_at=now,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                    session.add(lease)
+                    session.flush()
+
                 payload = {
                     "id": account.id,
                     "email": account.email,
                     "password": account.password,
                     "client_id": account.client_id,
                     "refresh_token": account.refresh_token,
+                    "lease_id": lease.id,
                 }
                 session.delete(account)
                 session.commit()
@@ -3482,12 +3556,56 @@ class OutlookMailbox(BaseMailbox):
                 "client_id": client_id,
                 "refresh_token": refresh_token,
                 "outlook_backend": self._backend_name,
+                "outlook_lease_id": payload.get("lease_id"),
             },
         )
 
+    def mark_account_success(self, account: MailboxAccount) -> None:
+        from sqlmodel import Session
+        from core.db import engine
+
+        email = str(getattr(account, "email", "") or "").strip()
+        if not email:
+            return
+
+        with self._lock:
+            with Session(engine) as session:
+                leased = self._find_leased_account(session, account)
+                if leased is None:
+                    return
+                session.delete(leased)
+                session.commit()
+        self._log(f"[微软邮箱] 账号注册完成，已清理恢复记录: {email}")
+
+    def mark_account_failure(self, account: MailboxAccount, error: str = "") -> None:
+        from sqlmodel import Session
+        from core.db import _utcnow, engine
+
+        email = str(getattr(account, "email", "") or "").strip()
+        if not email:
+            return
+
+        with self._lock:
+            with Session(engine) as session:
+                leased = self._find_leased_account(session, account)
+                if leased is None:
+                    return
+                now = _utcnow()
+                leased.status = "recoverable"
+                leased.last_error = str(error or "")
+                leased.last_failed_at = now
+                leased.updated_at = now
+                session.add(leased)
+                session.commit()
+        self._log(f"[微软邮箱] 账号保留在恢复池中: {email}")
+
     def requeue_account(self, account: MailboxAccount) -> None:
         from sqlmodel import Session, select
-        from core.db import engine, OutlookAccountModel
+        from core.db import (
+            OutlookAccountModel,
+            _utcnow,
+            engine,
+        )
 
         email = str(getattr(account, "email", "") or "").strip()
         extra = getattr(account, "extra", None) or {}
@@ -3500,11 +3618,20 @@ class OutlookMailbox(BaseMailbox):
 
         with self._lock:
             with Session(engine) as session:
+                leased = self._find_leased_account(session, account)
+                if leased is not None:
+                    password = password or str(leased.password or "")
+                    client_id = client_id or str(leased.client_id or "")
+                    refresh_token = refresh_token or str(leased.refresh_token or "")
+
                 existing = session.exec(
                     select(OutlookAccountModel).where(OutlookAccountModel.email == email)
                 ).first()
                 if existing:
                     existing.enabled = True
+                    existing.password = password or existing.password
+                    existing.client_id = client_id or existing.client_id
+                    existing.refresh_token = refresh_token or existing.refresh_token
                     existing.updated_at = _utcnow()
                     session.add(existing)
                 else:
@@ -3519,6 +3646,8 @@ class OutlookMailbox(BaseMailbox):
                             updated_at=_utcnow(),
                         )
                     )
+                if leased is not None:
+                    session.delete(leased)
                 session.commit()
         self._log(f"[微软邮箱] 账号已回退到本地池: {email}")
 

--- a/core/db.py
+++ b/core/db.py
@@ -63,6 +63,24 @@ class OutlookAccountModel(SQLModel, table=True):
     last_used: Optional[datetime] = None
 
 
+class OutlookAccountLeaseModel(SQLModel, table=True):
+    __tablename__ = "outlook_account_leases"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    email: str = Field(index=True, sa_column_kwargs={"unique": True})
+    password: str
+    client_id: str = ""
+    refresh_token: str = ""
+    source_account_id: Optional[int] = Field(default=None, index=True)
+    task_attempt_id: str = Field(default="", index=True)
+    status: str = Field(default="leased", index=True)
+    last_error: str = ""
+    leased_at: datetime = Field(default_factory=_utcnow)
+    last_failed_at: Optional[datetime] = None
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
 class ProxyModel(SQLModel, table=True):
     __tablename__ = "proxies"
 

--- a/core/proxy_pool.py
+++ b/core/proxy_pool.py
@@ -3,9 +3,15 @@
 from typing import Optional
 from sqlmodel import Session, select
 from .db import ProxyModel, engine
+from .config_store import config_store
 from .proxy_utils import build_requests_proxy_config
 import time, threading, random
 from datetime import datetime, timezone
+
+
+def _is_proxy_auto_disable_enabled() -> bool:
+    raw = str(config_store.get("proxy_auto_disable_enabled", "1") or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
 
 
 class ProxyPool:
@@ -46,8 +52,12 @@ class ProxyPool:
             if p:
                 p.fail_count += 1
                 p.last_checked = datetime.now(timezone.utc)
-                # 连续失败超过10次自动禁用
-                if p.fail_count > 0 and p.success_count == 0 and p.fail_count >= 5:
+                if (
+                    _is_proxy_auto_disable_enabled()
+                    and p.fail_count > 0
+                    and p.success_count == 0
+                    and p.fail_count >= 5
+                ):
                     p.is_active = False
                 s.add(p)
                 s.commit()

--- a/core/task_runtime.py
+++ b/core/task_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+import re
 import threading
 import time
 from typing import Any
@@ -27,11 +28,19 @@ class SkipCurrentAttemptRequested(TaskInterruption):
         super().__init__(message)
 
 
+class PauseTaskRequested(TaskInterruption):
+    """任务因为风险条件被自动暂停。"""
+
+    def __init__(self, message: str = "任务已暂停"):
+        super().__init__(message)
+
+
 class AttemptOutcome(str, Enum):
     SUCCESS = "success"
     FAILED = "failed"
     SKIPPED = "skipped"
     STOPPED = "stopped"
+    PAUSED = "paused"
 
 
 @dataclass(slots=True)
@@ -55,6 +64,43 @@ class AttemptResult:
     def stopped(cls, message: str) -> "AttemptResult":
         return cls(AttemptOutcome.STOPPED, message)
 
+    @classmethod
+    def paused(cls, message: str) -> "AttemptResult":
+        return cls(AttemptOutcome.PAUSED, message)
+
+
+def should_auto_pause_on_http_400(message: str) -> bool:
+    text = " ".join(str(message or "").lower().split())
+    if not text or "400" not in text:
+        return False
+
+    markers = (
+        "http 400",
+        "status code 400",
+        "status_code=400",
+        "status=400",
+        "注册失败: 400",
+        "登录失败: 400",
+        "请求失败: 400",
+        "失败: 400 -",
+    )
+    if any(marker in text for marker in markers):
+        return True
+
+    if re.search(r"\bhttp\b[^0-9]{0,12}\b400\b", text):
+        return True
+    if re.search(r"(?:^|[^0-9])400\s*-", text):
+        return True
+    return False
+
+
+def build_http_400_pause_reason(message: str) -> str:
+    detail = str(message or "").strip()
+    base = "检测到 HTTP 400，可能触发风控，已自动暂停注册任务"
+    if not detail:
+        return base
+    return f"{base}: {detail}"
+
 
 class RegisterTaskControl:
     """协作式任务控制器：支持停止整个任务、跳过一个当前账号。"""
@@ -62,6 +108,8 @@ class RegisterTaskControl:
     def __init__(self):
         self._lock = threading.Lock()
         self._stop_requested = False
+        self._pause_requested = False
+        self._pause_reason = ""
         self._pending_skip_requests = 0
         self._next_attempt_id = 1
         self._active_attempt_ids: set[int] = set()
@@ -70,6 +118,14 @@ class RegisterTaskControl:
     def request_stop(self) -> None:
         with self._lock:
             self._stop_requested = True
+
+    def request_pause(self, reason: str = "") -> bool:
+        with self._lock:
+            if self._pause_requested:
+                return False
+            self._pause_requested = True
+            self._pause_reason = str(reason or "").strip()
+            return True
 
     def request_skip_current(self) -> None:
         with self._lock:
@@ -101,6 +157,8 @@ class RegisterTaskControl:
         with self._lock:
             if self._stop_requested:
                 raise StopTaskRequested()
+            if self._pause_requested:
+                raise PauseTaskRequested(self._pause_reason or "任务已暂停")
             if consume_skip:
                 if (
                     attempt_id is not None
@@ -116,10 +174,20 @@ class RegisterTaskControl:
         with self._lock:
             return self._stop_requested
 
+    def is_pause_requested(self) -> bool:
+        with self._lock:
+            return self._pause_requested
+
+    def pause_reason(self) -> str:
+        with self._lock:
+            return self._pause_reason
+
     def snapshot(self) -> dict[str, Any]:
         with self._lock:
             return {
                 "stop_requested": self._stop_requested,
+                "pause_requested": self._pause_requested,
+                "pause_reason": self._pause_reason,
                 "pending_skip_requests": self._pending_skip_requests,
                 "active_attempts": len(self._active_attempt_ids),
                 "targeted_skip_attempts": len(self._skip_active_attempt_ids),
@@ -242,6 +310,11 @@ class RegisterTaskStore:
         control.request_skip_current()
         return control.snapshot()
 
+    def request_pause(self, task_id: str, reason: str = "") -> dict[str, Any]:
+        control = self.control_for(task_id)
+        control.request_pause(reason)
+        return control.snapshot()
+
     def append_log(self, task_id: str, entry: str) -> None:
         with self._lock:
             record = self._records.get(task_id)
@@ -327,7 +400,7 @@ class RegisterTaskStore:
             finished = [
                 (task_id, record)
                 for task_id, record in self._records.items()
-                if record.status in ("done", "failed", "stopped")
+                if record.status in ("done", "failed", "stopped", "paused")
             ]
             if len(finished) <= self.max_finished_tasks:
                 return
@@ -340,10 +413,13 @@ class RegisterTaskStore:
 __all__ = [
     "AttemptOutcome",
     "AttemptResult",
+    "build_http_400_pause_reason",
+    "PauseTaskRequested",
     "RegisterTaskControl",
     "RegisterTaskRecord",
     "RegisterTaskStore",
     "SkipCurrentAttemptRequested",
     "StopTaskRequested",
     "TaskInterruption",
+    "should_auto_pause_on_http_400",
 ]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,28 +1,33 @@
-import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom'
-import { useState, useEffect } from 'react'
-import { App as AntdApp, ConfigProvider, Layout, Menu, Button, Spin } from 'antd'
+import { useEffect, useState } from 'react'
+import { BrowserRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom'
+import { App as AntdApp, Button, ConfigProvider, Layout, Menu, Spin } from 'antd'
 import {
   DashboardOutlined,
-  UserOutlined,
   GlobalOutlined,
   HistoryOutlined,
+  InboxOutlined,
+  LogoutOutlined,
+  MoonOutlined,
+  PlayCircleOutlined,
   SettingOutlined,
   SunOutlined,
-  MoonOutlined,
-  LogoutOutlined,
+  UserOutlined,
 } from '@ant-design/icons'
 import zhCN from 'antd/locale/zh_CN'
-import Dashboard from '@/pages/Dashboard'
+
 import Accounts from '@/pages/Accounts'
-import RegisterTaskPage from '@/pages/RegisterTaskPage'
+import Dashboard from '@/pages/Dashboard'
+import Login from '@/pages/Login'
+import MailRecoveryPool from '@/pages/MailRecoveryPool'
 import Proxies from '@/pages/Proxies'
+import RegisterTaskPage from '@/pages/RegisterTaskPage'
 import Settings from '@/pages/Settings'
 import TaskHistory from '@/pages/TaskHistory'
-import Login from '@/pages/Login'
-import { darkTheme, lightTheme } from './theme'
 import { apiFetch, clearToken, getToken } from '@/lib/utils'
 
-const { Sider, Content } = Layout
+import { darkTheme, lightTheme } from './theme'
+
+const { Content, Sider } = Layout
 
 function ProtectedLayout() {
   const navigate = useNavigate()
@@ -30,17 +35,17 @@ function ProtectedLayout() {
 
   useEffect(() => {
     fetch('/api/auth/status')
-      .then(r => r.json())
-      .then(s => {
+      .then((response) => response.json())
+      .then((status) => {
         const token = getToken()
-        if (s.has_password && !token) {
+        if (status.has_password && !token) {
           navigate('/login', { replace: true })
-        } else {
-          setReady(true)
+          return
         }
+        setReady(true)
       })
       .catch(() => setReady(true))
-  }, [])
+  }, [navigate])
 
   if (!ready) {
     return (
@@ -55,7 +60,7 @@ function ProtectedLayout() {
 
 function AppContent() {
   const [themeMode, setThemeMode] = useState<'dark' | 'light'>(() =>
-    (localStorage.getItem('theme') as 'dark' | 'light') || 'dark'
+    (localStorage.getItem('theme') as 'dark' | 'light') || 'dark',
   )
   const [collapsed, setCollapsed] = useState(false)
   const [platforms, setPlatforms] = useState<{ key: string; label: string }[]>([])
@@ -67,20 +72,25 @@ function AppContent() {
     document.documentElement.classList.toggle('light', themeMode === 'light')
     document.documentElement.style.setProperty(
       '--sider-trigger-border',
-      themeMode === 'light' ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.15)'
+      themeMode === 'light' ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.15)',
     )
     localStorage.setItem('theme', themeMode)
   }, [themeMode])
 
   useEffect(() => {
-    fetch('/api/auth/status').then(r => r.json()).then(s => setHasPassword(s.has_password)).catch(() => {})
+    fetch('/api/auth/status')
+      .then((response) => response.json())
+      .then((status) => setHasPassword(status.has_password))
+      .catch(() => {})
   }, [])
 
   useEffect(() => {
     apiFetch('/platforms')
-      .then(d => setPlatforms((d || [])
-        .filter((p: any) => !['tavily', 'cursor'].includes(p.name))
-        .map((p: any) => ({ key: p.name, label: p.display_name }))))
+      .then((data) => setPlatforms(
+        (data || [])
+          .filter((platform: any) => !['tavily', 'cursor'].includes(platform.name))
+          .map((platform: any) => ({ key: platform.name, label: platform.display_name })),
+      ))
       .catch(() => {})
   }, [])
 
@@ -90,9 +100,11 @@ function AppContent() {
   const getSelectedKey = () => {
     const path = location.pathname
     if (path === '/') return ['/']
+    if (path === '/register') return ['/register']
     if (path.startsWith('/accounts')) return [path]
     if (path === '/history') return ['/history']
     if (path === '/proxies') return ['/proxies']
+    if (path === '/mail-recovery') return ['/mail-recovery']
     if (path === '/settings') return ['/settings']
     return ['/']
   }
@@ -104,12 +116,17 @@ function AppContent() {
       label: '仪表盘',
     },
     {
+      key: '/register',
+      icon: <PlayCircleOutlined />,
+      label: '注册任务',
+    },
+    {
       key: '/accounts',
       icon: <UserOutlined />,
       label: '平台管理',
-      children: platforms.map(p => ({
-        key: `/accounts/${p.key}`,
-        label: p.label,
+      children: platforms.map((platform) => ({
+        key: `/accounts/${platform.key}`,
+        label: platform.label,
       })),
     },
     {
@@ -123,6 +140,11 @@ function AppContent() {
       label: '代理管理',
     },
     {
+      key: '/mail-recovery',
+      icon: <InboxOutlined />,
+      label: '微软恢复池',
+    },
+    {
       key: '/settings',
       icon: <SettingOutlined />,
       label: '全局配置',
@@ -132,110 +154,114 @@ function AppContent() {
   return (
     <ConfigProvider theme={currentTheme} locale={zhCN}>
       <AntdApp>
-      <Layout style={{ minHeight: '100vh' }}>
-        <Sider
-          collapsible
-          collapsed={collapsed}
-          onCollapse={setCollapsed}
-          style={{
-            background: currentTheme.token?.colorBgContainer,
-            borderRight: `1px solid ${currentTheme.token?.colorBorder}`,
-          }}
-          width={220}
-        >
-          <div
+        <Layout style={{ minHeight: '100vh' }}>
+          <Sider
+            collapsible
+            collapsed={collapsed}
+            onCollapse={setCollapsed}
             style={{
-              height: 64,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              borderBottom: `1px solid ${currentTheme.token?.colorBorder}`,
+              background: currentTheme.token?.colorBgContainer,
+              borderRight: `1px solid ${currentTheme.token?.colorBorder}`,
             }}
+            width={220}
           >
-            <DashboardOutlined style={{ fontSize: 20, color: currentTheme.token?.colorPrimary }} />
-            {!collapsed && (
-              <span
-                style={{
-                  marginLeft: 8,
-                  fontWeight: 600,
-                  fontSize: 14,
-                  color: currentTheme.token?.colorText,
-                }}
-              >
-                Account Manager
-              </span>
-            )}
-          </div>
-          <Menu
-            mode="inline"
-            selectedKeys={getSelectedKey()}
-            defaultOpenKeys={['/accounts']}
-            items={menuItems}
-            onClick={({ key }) => navigate(key)}
-            style={{
-              borderRight: 0,
-              background: 'transparent',
-            }}
-          />
-          <div
-            style={{
-              position: 'absolute',
-              bottom: 56,
-              left: 0,
-              right: 0,
-              padding: '0 16px',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 8,
-            }}
-          >
-            <Button
-              block
-              icon={isLight ? <SunOutlined /> : <MoonOutlined />}
-              onClick={() => setThemeMode(isLight ? 'dark' : 'light')}
+            <div
               style={{
+                height: 64,
                 display: 'flex',
                 alignItems: 'center',
-                justifyContent: collapsed ? 'center' : 'space-between',
+                justifyContent: 'center',
+                borderBottom: `1px solid ${currentTheme.token?.colorBorder}`,
               }}
             >
-              {!collapsed && (isLight ? '亮色模式' : '暗色模式')}
-            </Button>
-            {hasPassword && (
+              <DashboardOutlined style={{ fontSize: 20, color: currentTheme.token?.colorPrimary }} />
+              {!collapsed && (
+                <span
+                  style={{
+                    marginLeft: 8,
+                    fontWeight: 600,
+                    fontSize: 14,
+                    color: currentTheme.token?.colorText,
+                  }}
+                >
+                  Account Manager
+                </span>
+              )}
+            </div>
+            <Menu
+              mode="inline"
+              selectedKeys={getSelectedKey()}
+              defaultOpenKeys={['/accounts']}
+              items={menuItems}
+              onClick={({ key }) => navigate(key)}
+              style={{
+                borderRight: 0,
+                background: 'transparent',
+              }}
+            />
+            <div
+              style={{
+                position: 'absolute',
+                bottom: 56,
+                left: 0,
+                right: 0,
+                padding: '0 16px',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 8,
+              }}
+            >
               <Button
                 block
-                danger
-                icon={<LogoutOutlined />}
-                onClick={() => { clearToken(); navigate('/login') }}
+                icon={isLight ? <SunOutlined /> : <MoonOutlined />}
+                onClick={() => setThemeMode(isLight ? 'dark' : 'light')}
                 style={{
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: collapsed ? 'center' : 'space-between',
                 }}
               >
-                {!collapsed && '退出登录'}
+                {!collapsed && (isLight ? '亮色模式' : '暗色模式')}
               </Button>
-            )}
-          </div>
-        </Sider>
-        <Content
-          style={{
-            padding: 24,
-            overflow: 'auto',
-            background: currentTheme.token?.colorBgLayout,
-          }}
-        >
-          <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/accounts" element={<Accounts />} />
-            <Route path="/accounts/:platform" element={<Accounts />} />
-            <Route path="/register" element={<RegisterTaskPage />} />
-            <Route path="/history" element={<TaskHistory />} />
-            <Route path="/proxies" element={<Proxies />} />
-            <Route path="/settings" element={<Settings />} />
-          </Routes>
-        </Content>
-      </Layout>
+              {hasPassword && (
+                <Button
+                  block
+                  danger
+                  icon={<LogoutOutlined />}
+                  onClick={() => {
+                    clearToken()
+                    navigate('/login')
+                  }}
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: collapsed ? 'center' : 'space-between',
+                  }}
+                >
+                  {!collapsed && '退出登录'}
+                </Button>
+              )}
+            </div>
+          </Sider>
+          <Content
+            style={{
+              padding: 24,
+              overflow: 'auto',
+              background: currentTheme.token?.colorBgLayout,
+            }}
+          >
+            <Routes>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/accounts" element={<Accounts />} />
+              <Route path="/accounts/:platform" element={<Accounts />} />
+              <Route path="/register" element={<RegisterTaskPage />} />
+              <Route path="/history" element={<TaskHistory />} />
+              <Route path="/proxies" element={<Proxies />} />
+              <Route path="/mail-recovery" element={<MailRecoveryPool />} />
+              <Route path="/settings" element={<Settings />} />
+            </Routes>
+          </Content>
+        </Layout>
       </AntdApp>
     </ConfigProvider>
   )

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import {
   Table,
   Button,
+  Checkbox,
   Input,
   InputNumber,
   Select,
@@ -542,6 +543,7 @@ export default function Accounts() {
   const [detailForm] = Form.useForm()
   const { mode: chatgptRegistrationMode, setMode: setChatgptRegistrationMode } =
     usePersistentChatGPTRegistrationMode()
+  const registerAutoPauseOnHttp400 = Form.useWatch('auto_pause_on_http_400', registerForm) !== false
   const [importText, setImportText] = useState('')
   const [importLoading, setImportLoading] = useState(false)
   const [taskId, setTaskId] = useState<string | null>(null)
@@ -805,6 +807,7 @@ export default function Accounts() {
           count: values.count,
           concurrency: values.concurrency,
           register_delay_seconds: values.register_delay_seconds || 0,
+          auto_pause_on_http_400: values.auto_pause_on_http_400 !== false,
           executor_type: executorType,
           captcha_solver: cfg.default_captcha_solver || 'yescaptcha',
           proxy: null,
@@ -1368,15 +1371,42 @@ export default function Accounts() {
         maskClosable={false}
       >
         {!taskId ? (
-          <Form form={registerForm} layout="vertical" onFinish={handleRegister}>
-            <Form.Item name="count" label="注册数量" initialValue={1} rules={[{ required: true }]}>
+          <Form
+            form={registerForm}
+            layout="vertical"
+            onFinish={handleRegister}
+            initialValues={{
+              count: 1,
+              concurrency: 1,
+              register_delay_seconds: 0,
+              auto_pause_on_http_400: true,
+            }}
+          >
+            <Form.Item name="count" label="注册数量" rules={[{ required: true }]}>
               <Input type="number" min={1} />
             </Form.Item>
-            <Form.Item name="concurrency" label="并发数" initialValue={1} rules={[{ required: true }]}>
+            <Form.Item name="concurrency" label="并发数" rules={[{ required: true }]}>
               <Input type="number" min={1} max={5} />
             </Form.Item>
-            <Form.Item name="register_delay_seconds" label="每个注册延迟(秒)" initialValue={0}>
+            <Form.Item name="register_delay_seconds" label="每个注册延迟(秒)">
               <InputNumber min={0} precision={1} step={0.5} style={{ width: '100%' }} placeholder="0 = 不延迟" />
+            </Form.Item>
+            <Form.Item label="风控策略" style={{ marginBottom: 16 }}>
+              <Space direction="vertical" size={12} style={{ width: '100%' }}>
+                <Alert
+                  showIcon
+                  type={registerAutoPauseOnHttp400 ? 'warning' : 'info'}
+                  message={registerAutoPauseOnHttp400 ? '已开启 HTTP 400 自动暂停' : '已关闭 HTTP 400 自动暂停'}
+                  description={
+                    registerAutoPauseOnHttp400
+                      ? '命中 HTTP 400 时会暂停整个注册任务，避免继续消耗邮箱。'
+                      : '命中 HTTP 400 时只记录失败，任务会继续执行。'
+                  }
+                />
+                <Form.Item name="auto_pause_on_http_400" valuePropName="checked" noStyle>
+                  <Checkbox>命中 HTTP 400 时自动暂停整个任务</Checkbox>
+                </Form.Item>
+              </Space>
             </Form.Item>
             {currentPlatform === 'chatgpt' && (
               <Form.Item label="ChatGPT Token 方案">

--- a/frontend/src/pages/MailRecoveryPool.tsx
+++ b/frontend/src/pages/MailRecoveryPool.tsx
@@ -1,0 +1,364 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  Alert,
+  App,
+  Button,
+  Card,
+  Col,
+  Input,
+  Popconfirm,
+  Row,
+  Select,
+  Space,
+  Statistic,
+  Table,
+  Tag,
+  Typography,
+  theme,
+} from 'antd'
+import type { TableColumnsType } from 'antd'
+import { InboxOutlined, ReloadOutlined } from '@ant-design/icons'
+
+import { apiFetch } from '@/lib/utils'
+
+const { Text, Paragraph } = Typography
+
+type RecoveryMailboxFilter = 'all' | 'outlook' | 'hotmail'
+type RecoveryMailboxType = 'outlook' | 'hotmail' | 'other'
+type RecoveryStatusFilter = 'all' | 'leased' | 'recoverable'
+
+interface RecoveryPoolItem {
+  id: number
+  email: string
+  mailbox_type: RecoveryMailboxType
+  status: string
+  has_oauth: boolean
+  source_account_id?: number | null
+  task_attempt_id: string
+  last_error: string
+  leased_at?: string | null
+  last_failed_at?: string | null
+  updated_at?: string | null
+}
+
+interface RecoveryPoolSummary {
+  total: number
+  leased: number
+  recoverable: number
+  hotmail: number
+  outlook: number
+  other: number
+}
+
+interface RecoveryPoolResponse {
+  mailbox_type: RecoveryMailboxFilter
+  status: RecoveryStatusFilter
+  search: string
+  count: number
+  items: RecoveryPoolItem[]
+  truncated: boolean
+  summary: RecoveryPoolSummary
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) return '-'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return date.toLocaleString('zh-CN')
+}
+
+function getMailboxMeta(type: RecoveryMailboxType) {
+  switch (type) {
+    case 'hotmail':
+      return { color: 'processing' as const, label: 'Hotmail' }
+    case 'outlook':
+      return { color: 'success' as const, label: 'Outlook' }
+    default:
+      return { color: 'default' as const, label: '其他' }
+  }
+}
+
+function getStatusMeta(status: string) {
+  if (status === 'recoverable') {
+    return { color: 'warning' as const, label: '可恢复' }
+  }
+  if (status === 'leased') {
+    return { color: 'processing' as const, label: '租用中' }
+  }
+  return { color: 'default' as const, label: status || '未知' }
+}
+
+export default function MailRecoveryPool() {
+  const { message } = App.useApp()
+  const { token } = theme.useToken()
+  const [mailboxType, setMailboxType] = useState<RecoveryMailboxFilter>('hotmail')
+  const [status, setStatus] = useState<RecoveryStatusFilter>('all')
+  const [searchInput, setSearchInput] = useState('')
+  const [search, setSearch] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [restoringId, setRestoringId] = useState<number | null>(null)
+  const [snapshot, setSnapshot] = useState<RecoveryPoolResponse | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const params = new URLSearchParams({
+        mailbox_type: mailboxType,
+        status,
+        limit: '200',
+      })
+      if (search.trim()) {
+        params.set('search', search.trim())
+      }
+      const data = await apiFetch(`/mail-imports/recovery-pool?${params.toString()}`) as RecoveryPoolResponse
+      setSnapshot(data)
+    } finally {
+      setLoading(false)
+    }
+  }, [mailboxType, search, status])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const handleRestore = async (item: RecoveryPoolItem) => {
+    setRestoringId(item.id)
+    try {
+      await apiFetch('/mail-imports/recovery-pool/restore', {
+        method: 'POST',
+        body: JSON.stringify({ id: item.id }),
+      })
+      message.success(`已恢复到可用池: ${item.email}`)
+      await load()
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : '恢复微软邮箱失败'
+      message.error(detail)
+    } finally {
+      setRestoringId(null)
+    }
+  }
+
+  const statCards = useMemo(() => ([
+    {
+      title: '当前命中',
+      value: snapshot?.count ?? 0,
+      color: token.colorPrimary,
+    },
+    {
+      title: '可恢复',
+      value: snapshot?.summary.recoverable ?? 0,
+      color: token.colorWarning,
+    },
+    {
+      title: '租用中',
+      value: snapshot?.summary.leased ?? 0,
+      color: token.colorInfo,
+    },
+    {
+      title: 'Hotmail',
+      value: snapshot?.summary.hotmail ?? 0,
+      color: token.colorSuccess,
+    },
+  ]), [
+    snapshot?.count,
+    snapshot?.summary.hotmail,
+    snapshot?.summary.leased,
+    snapshot?.summary.recoverable,
+    token.colorInfo,
+    token.colorPrimary,
+    token.colorSuccess,
+    token.colorWarning,
+  ])
+
+  const columns: TableColumnsType<RecoveryPoolItem> = [
+    {
+      title: '邮箱',
+      dataIndex: 'email',
+      key: 'email',
+      width: 300,
+      render: (_value, record) => {
+        const mailboxMeta = getMailboxMeta(record.mailbox_type)
+        return (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <Space size={[8, 8]} wrap>
+              <Text style={{ fontFamily: 'monospace', fontSize: 12 }}>{record.email}</Text>
+              <Tag color={mailboxMeta.color}>{mailboxMeta.label}</Tag>
+              {record.has_oauth ? <Tag color="success">OAuth</Tag> : <Tag>无 OAuth</Tag>}
+            </Space>
+            {record.task_attempt_id ? (
+              <Text type="secondary" style={{ fontSize: 12 }}>
+                尝试标识: <span style={{ fontFamily: 'monospace' }}>{record.task_attempt_id}</span>
+              </Text>
+            ) : null}
+          </div>
+        )
+      },
+    },
+    {
+      title: '状态',
+      dataIndex: 'status',
+      key: 'status',
+      width: 120,
+      render: (value: string) => {
+        const meta = getStatusMeta(value)
+        return <Tag color={meta.color}>{meta.label}</Tag>
+      },
+    },
+    {
+      title: '最近错误',
+      dataIndex: 'last_error',
+      key: 'last_error',
+      render: (_value, record) => (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {record.last_error ? (
+            <Paragraph
+              style={{ marginBottom: 0 }}
+              ellipsis={{ rows: 2, tooltip: record.last_error }}
+            >
+              {record.last_error}
+            </Paragraph>
+          ) : (
+            <Text type="secondary">-</Text>
+          )}
+          <Text type="secondary" style={{ fontSize: 12 }}>
+            最近失败: {formatDateTime(record.last_failed_at)}
+          </Text>
+        </div>
+      ),
+    },
+    {
+      title: '租用时间',
+      dataIndex: 'leased_at',
+      key: 'leased_at',
+      width: 180,
+      render: (value?: string | null) => formatDateTime(value),
+    },
+    {
+      title: '更新时间',
+      dataIndex: 'updated_at',
+      key: 'updated_at',
+      width: 180,
+      render: (value?: string | null) => formatDateTime(value),
+    },
+    {
+      title: '操作',
+      key: 'actions',
+      width: 140,
+      fixed: 'right',
+      render: (_value, record) => (
+        record.status === 'recoverable' ? (
+          <Popconfirm
+            title="确认恢复到可用池？"
+            description="恢复后该邮箱会重新出现在可用池预览里，并可能再次被注册任务取用。"
+            onConfirm={() => handleRestore(record)}
+          >
+            <Button
+              type="link"
+              size="small"
+              loading={restoringId === record.id}
+            >
+              恢复
+            </Button>
+          </Popconfirm>
+        ) : (
+          <Text type="secondary">-</Text>
+        )
+      ),
+    },
+  ]
+
+  return (
+    <div className="page-enter" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16 }}>
+        <div>
+          <Space align="center" size={10}>
+            <InboxOutlined style={{ fontSize: 22, color: token.colorPrimary }} />
+            <h1 style={{ fontSize: 24, fontWeight: 'bold', margin: 0 }}>微软恢复池</h1>
+          </Space>
+          <p style={{ color: token.colorTextSecondary, marginTop: 6 }}>
+            查看仍可恢复的 Outlook / Hotmail 邮箱。页面默认聚焦 Hotmail。
+          </p>
+        </div>
+        <Button icon={<ReloadOutlined spin={loading} />} onClick={load} loading={loading}>
+          刷新
+        </Button>
+      </div>
+
+      <Alert
+        type="info"
+        showIcon
+        message="恢复池说明"
+        description="微软邮箱被取用后会先进入恢复池。只有当 token_exchange 成功并完成账号落库后，恢复记录才会被清理；注册失败或拿不到 token 的邮箱会保留在这里。"
+      />
+
+      <Row gutter={[16, 16]}>
+        {statCards.map((card) => (
+          <Col xs={24} sm={12} xl={6} key={card.title}>
+            <Card>
+              <Statistic
+                title={card.title}
+                value={card.value}
+                valueStyle={{ color: card.color }}
+              />
+            </Card>
+          </Col>
+        ))}
+      </Row>
+
+      <Card>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <Space size={[12, 12]} wrap>
+            <Select
+              value={mailboxType}
+              onChange={(value) => setMailboxType(value)}
+              style={{ width: 160 }}
+              options={[
+                { value: 'hotmail', label: 'Hotmail' },
+                { value: 'outlook', label: 'Outlook' },
+                { value: 'all', label: '全部类型' },
+              ]}
+            />
+            <Select
+              value={status}
+              onChange={(value) => setStatus(value)}
+              style={{ width: 160 }}
+              options={[
+                { value: 'all', label: '全部状态' },
+                { value: 'recoverable', label: '可恢复' },
+                { value: 'leased', label: '租用中' },
+              ]}
+            />
+            <Input.Search
+              allowClear
+              placeholder="搜索邮箱、错误信息或尝试标识"
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+              onSearch={(value) => setSearch(value.trim())}
+              style={{ width: 320 }}
+            />
+          </Space>
+          <Space size={[8, 8]} wrap>
+            <Text type="secondary">
+              当前筛选命中 {snapshot?.count ?? 0} 条
+              {snapshot?.truncated ? '，仅展示前 200 条' : ''}
+            </Text>
+            <Tag>Hotmail {snapshot?.summary.hotmail ?? 0}</Tag>
+            <Tag>Outlook {snapshot?.summary.outlook ?? 0}</Tag>
+            {(snapshot?.summary.other ?? 0) > 0 ? <Tag>其他 {snapshot?.summary.other ?? 0}</Tag> : null}
+          </Space>
+        </div>
+      </Card>
+
+      <Card bodyStyle={{ padding: 0 }}>
+        <Table
+          rowKey="id"
+          loading={loading}
+          columns={columns}
+          dataSource={snapshot?.items ?? []}
+          pagination={{ pageSize: 20, showSizeChanger: false }}
+          scroll={{ x: 1080 }}
+        />
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/Proxies.tsx
+++ b/frontend/src/pages/Proxies.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Card, Table, Button, Input, Tag, Space, Popconfirm, message } from 'antd'
+import { Alert, Card, Table, Button, Input, Tag, Space, Popconfirm, Switch, message } from 'antd'
 import {
   PlusOutlined,
   DeleteOutlined,
@@ -9,6 +9,7 @@ import {
   SwapRightOutlined,
   SwapLeftOutlined,
 } from '@ant-design/icons'
+import { parseBooleanConfigValue } from '@/lib/configValueParsers'
 import { apiFetch } from '@/lib/utils'
 
 export default function Proxies() {
@@ -17,6 +18,8 @@ export default function Proxies() {
   const [region, setRegion] = useState('')
   const [checking, setChecking] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [autoDisableEnabled, setAutoDisableEnabled] = useState(true)
+  const [savingAutoDisable, setSavingAutoDisable] = useState(false)
 
   const load = async () => {
     setLoading(true)
@@ -28,8 +31,14 @@ export default function Proxies() {
     }
   }
 
+  const loadConfig = async () => {
+    const data = await apiFetch('/config')
+    setAutoDisableEnabled(parseBooleanConfigValue(data.proxy_auto_disable_enabled || '1'))
+  }
+
   useEffect(() => {
     load()
+    loadConfig().catch(() => {})
   }, [])
 
   const add = async () => {
@@ -74,6 +83,24 @@ export default function Proxies() {
       load()
       setChecking(false)
     }, 3000)
+  }
+
+  const updateAutoDisable = async (checked: boolean) => {
+    setSavingAutoDisable(true)
+    try {
+      await apiFetch('/config', {
+        method: 'PUT',
+        body: JSON.stringify({
+          data: {
+            proxy_auto_disable_enabled: checked ? '1' : '0',
+          },
+        }),
+      })
+      setAutoDisableEnabled(checked)
+      message.success(checked ? '已开启代理自动禁用' : '已关闭代理自动禁用')
+    } finally {
+      setSavingAutoDisable(false)
+    }
   }
 
   const columns: any[] = [
@@ -161,6 +188,36 @@ export default function Proxies() {
               添加
             </Button>
           </Space>
+        </Space>
+      </Card>
+
+      <Card title="自动禁用策略">
+        <Space direction="vertical" size={12} style={{ width: '100%' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16 }}>
+            <div>
+              <div style={{ fontWeight: 500, marginBottom: 4 }}>代理累计失败且从未成功时自动禁用</div>
+              <div style={{ color: '#7a8ba3', fontSize: 12 }}>
+                关闭后仍会继续累计成功/失败次数，但不会自动把代理标记为禁用。
+              </div>
+            </div>
+            <Switch
+              checked={autoDisableEnabled}
+              loading={savingAutoDisable}
+              checkedChildren="开启"
+              unCheckedChildren="关闭"
+              onChange={updateAutoDisable}
+            />
+          </div>
+          <Alert
+            showIcon
+            type={autoDisableEnabled ? 'warning' : 'info'}
+            message={autoDisableEnabled ? '当前已开启代理自动禁用' : '当前已关闭代理自动禁用'}
+            description={
+              autoDisableEnabled
+                ? '命中当前自动禁用条件后，代理会被自动标记为禁用，不再参与轮询。'
+                : '命中当前自动禁用条件后，代理仍保持活跃，需要你手动决定是否禁用。'
+            }
+          />
         </Space>
       </Card>
 

--- a/frontend/src/pages/RegisterTaskPage.tsx
+++ b/frontend/src/pages/RegisterTaskPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import {
+  Alert,
   Card,
   Form,
   Input,
@@ -191,6 +192,7 @@ export default function RegisterTaskPage() {
         count: values.count,
         concurrency: values.concurrency,
         register_delay_seconds: values.register_delay_seconds || 0,
+        auto_pause_on_http_400: values.auto_pause_on_http_400 !== false,
         proxy: values.proxy || null,
         executor_type: values.executor_type,
         captcha_solver: values.captcha_solver,
@@ -206,7 +208,7 @@ export default function RegisterTaskPage() {
     const interval = setInterval(async () => {
       const t = await apiFetch(`/tasks/${id}`)
       setTask(t)
-      if (t.status === 'done' || t.status === 'failed' || t.status === 'stopped') {
+      if (t.status === 'done' || t.status === 'failed' || t.status === 'stopped' || t.status === 'paused') {
         clearInterval(interval)
         setPolling(false)
         if (t.cashier_urls && t.cashier_urls.length > 0) {
@@ -221,6 +223,7 @@ export default function RegisterTaskPage() {
   const mailProvider = resolveEffectiveMailProvider(String(mailProviderRaw || ''), String(mailImportSource || 'microsoft'))
   const captchaSolver = Form.useWatch('captcha_solver', form)
   const platform = Form.useWatch('platform', form)
+  const autoPauseOnHttp400 = Form.useWatch('auto_pause_on_http_400', form) !== false
   const executorOptions = getExecutorOptions(platform)
 
   useEffect(() => {
@@ -253,6 +256,7 @@ export default function RegisterTaskPage() {
         count: 1,
         concurrency: 1,
         register_delay_seconds: 0,
+        auto_pause_on_http_400: true,
         maliapi_base_url: 'https://maliapi.215.im/v1',
         maliapi_auto_domain_strategy: 'balanced',
         solver_url: 'http://localhost:8889',
@@ -299,6 +303,23 @@ export default function RegisterTaskPage() {
               <Input placeholder="http://user:pass@host:port" />
             </Form.Item>
           </Space>
+          <Form.Item label="风控策略" style={{ marginBottom: 16 }}>
+            <Space direction="vertical" size={12} style={{ width: '100%' }}>
+              <Alert
+                showIcon
+                type={autoPauseOnHttp400 ? 'warning' : 'info'}
+                message={autoPauseOnHttp400 ? '已开启 HTTP 400 自动暂停' : '已关闭 HTTP 400 自动暂停'}
+                description={
+                  autoPauseOnHttp400
+                    ? '命中 HTTP 400 时会暂停整个注册任务，避免继续消耗邮箱。'
+                    : '命中 HTTP 400 时只记录失败，任务会继续执行。'
+                }
+              />
+              <Form.Item name="auto_pause_on_http_400" valuePropName="checked" noStyle>
+                <Checkbox>命中 HTTP 400 时自动暂停整个任务</Checkbox>
+              </Form.Item>
+            </Space>
+          </Form.Item>
           {platform === 'chatgpt' && (
             <Form.Item label="ChatGPT Token 方案">
               <ChatGPTRegistrationModeSwitch
@@ -621,6 +642,7 @@ export default function RegisterTaskPage() {
             <span>任务状态</span>
             <Tag color={
               task.status === 'done' ? 'success' :
+              task.status === 'paused' ? 'warning' :
               task.status === 'stopped' ? 'warning' :
               task.status === 'failed' ? 'error' : 'processing'
             }>

--- a/platforms/chatgpt/access_token_only_registration_engine.py
+++ b/platforms/chatgpt/access_token_only_registration_engine.py
@@ -8,7 +8,7 @@ import logging
 from datetime import datetime
 from typing import Optional, Callable
 
-from core.task_runtime import TaskInterruption
+from core.task_runtime import TaskInterruption, should_auto_pause_on_http_400
 from platforms.chatgpt.refresh_token_registration_engine import RegistrationResult
 
 from .chatgpt_client import ChatGPTClient
@@ -72,6 +72,9 @@ class AccessTokenOnlyRegistrationEngine:
             logger.info(log_message)
 
     def _should_retry(self, message: str) -> bool:
+        if should_auto_pause_on_http_400(message):
+            return False
+
         text = str(message or "").lower()
         retriable_markers = [
             "tls",
@@ -80,7 +83,6 @@ class AccessTokenOnlyRegistrationEngine:
             "预授权被拦截",
             "authorize",
             "registration_disallowed",
-            "http 400",
             "创建账号失败",
             "未获取到 authorization code",
             "consent",

--- a/platforms/chatgpt/oauth_client.py
+++ b/platforms/chatgpt/oauth_client.py
@@ -1656,6 +1656,7 @@ class OAuthClient:
         birthdate="",
         login_source="",
         stop_after_login=False,
+        allow_cached_code_retry=False,
         _continue_depth=0,
     ):
         """
@@ -1679,6 +1680,7 @@ class OAuthClient:
             last_name: about_you 姓氏
             birthdate: about_you 生日，格式 YYYY-MM-DD
             login_source: 当前登录场景，仅用于日志
+            allow_cached_code_retry: 是否允许优先尝试最近一次缓存验证码
 
         Returns:
             dict: tokens 字典，包含 access_token, refresh_token, id_token
@@ -1699,7 +1701,8 @@ class OAuthClient:
             f"force_password_login={'on' if force_password_login else 'off'}, "
             f"force_chatgpt_entry={'on' if force_chatgpt_entry else 'off'}, "
             f"screen_hint={screen_hint or 'login'}, "
-            f"stop_after_login={'on' if stop_after_login else 'off'}"
+            f"stop_after_login={'on' if stop_after_login else 'off'}, "
+            f"allow_cached_code_retry={'on' if allow_cached_code_retry else 'off'}"
         )
 
         if force_new_browser:
@@ -1920,7 +1923,7 @@ class OAuthClient:
                     skymail_client,
                     state,
                     prefer_passwordless_login=prefer_passwordless_login,
-                    allow_cached_code_retry=_continue_depth > 0,
+                    allow_cached_code_retry=allow_cached_code_retry or _continue_depth > 0,
                 )
                 if not next_state:
                     if not self.last_error:
@@ -2027,6 +2030,7 @@ class OAuthClient:
                                 if login_source
                                 else "add_phone_continue"
                             ),
+                            allow_cached_code_retry=allow_cached_code_retry,
                             _continue_depth=_continue_depth + 1,
                         )
                     else:

--- a/platforms/chatgpt/plugin.py
+++ b/platforms/chatgpt/plugin.py
@@ -181,6 +181,35 @@ class ChatGPTPlatform(BasePlatform):
 
             email_service = TempMailEmailService()
 
+        mailbox_finalized = False
+
+        def _finalize_mailbox(success: bool, error=None) -> None:
+            nonlocal mailbox_finalized
+            if mailbox_finalized or not self.mailbox:
+                return
+
+            mailbox_account = getattr(email_service, "_acct", None)
+            if mailbox_account is None:
+                return
+
+            try:
+                if success:
+                    mark_success = getattr(self.mailbox, "mark_account_success", None)
+                    if callable(mark_success):
+                        mark_success(mailbox_account)
+                else:
+                    failure_message = str(error or "").strip()
+                    mark_failure = getattr(self.mailbox, "mark_account_failure", None)
+                    if callable(mark_failure):
+                        mark_failure(mailbox_account, error=failure_message)
+                    else:
+                        requeue = getattr(self.mailbox, "requeue_account", None)
+                        if callable(requeue):
+                            requeue(mailbox_account)
+                mailbox_finalized = True
+            except Exception as exc:
+                log_fn(f"[Mailbox] 状态回写失败: {exc}")
+
         adapter = build_chatgpt_registration_mode_adapter(extra_config)
         context = ChatGPTRegistrationContext(
             email_service=email_service,
@@ -192,11 +221,19 @@ class ChatGPTPlatform(BasePlatform):
             max_retries=max_retries,
             extra_config=extra_config,
         )
-        result = adapter.run(context)
+        try:
+            result = adapter.run(context)
+        except Exception as exc:
+            _finalize_mailbox(False, exc)
+            raise
+
         if not result or not result.success:
+            _finalize_mailbox(False, result.error_message if result else "")
             raise RuntimeError(result.error_message if result else "注册失败")
 
-        return adapter.build_account(result, password)
+        account = adapter.build_account(result, password)
+        _finalize_mailbox(True)
+        return account
 
     def get_platform_actions(self) -> list:
         return [

--- a/platforms/chatgpt/refresh_token_registration_engine.py
+++ b/platforms/chatgpt/refresh_token_registration_engine.py
@@ -501,6 +501,7 @@ class RefreshTokenRegistrationEngine:
                     last_name=last_name,
                     birthdate=birthdate,
                     login_source="post_register_workspace_continue",
+                    allow_cached_code_retry=True,
                 )
             else:
                 self._log("3. 新开 OAuth session，按 screen_hint=login + passwordless OTP 登录...")
@@ -526,6 +527,7 @@ class RefreshTokenRegistrationEngine:
                     login_source=(
                         "existing_account_continue" if source == "login" else "post_register_workspace_continue"
                     ),
+                    allow_cached_code_retry=(source != "login"),
                 )
 
             if not tokens:

--- a/services/mail_imports/providers.py
+++ b/services/mail_imports/providers.py
@@ -10,7 +10,7 @@ from core.applemail_pool import (
     save_applemail_pool_json,
 )
 from core.config_store import config_store
-from core.db import OutlookAccountModel, engine
+from core.db import OutlookAccountLeaseModel, OutlookAccountModel, engine
 
 from .base import BaseMailImportStrategy
 from .microsoft_import_rules import (
@@ -285,7 +285,9 @@ class MicrosoftMailImportStrategy(BaseMailImportStrategy):
     def get_snapshot(self, request: MailImportSnapshotRequest) -> MailImportSnapshot:
         with Session(engine) as session:
             accounts = session.exec(
-                select(OutlookAccountModel).order_by(OutlookAccountModel.id)
+                select(OutlookAccountModel)
+                .where(OutlookAccountModel.enabled == True)
+                .order_by(OutlookAccountModel.id)
             ).all()
 
         limit = max(int(request.preview_limit or 0), 0)
@@ -326,6 +328,14 @@ class MicrosoftMailImportStrategy(BaseMailImportStrategy):
                 str(email or "").strip()
                 for email in session.exec(select(OutlookAccountModel.email)).all()
             }
+            existing_emails.update(
+                {
+                    str(email or "").strip()
+                    for email in session.exec(
+                        select(OutlookAccountLeaseModel.email)
+                    ).all()
+                }
+            )
             engine_ctx = {"existing_emails": existing_emails}
             rule_engine = MicrosoftMailImportRuleEngine([
                 DuplicateMicrosoftMailboxRule(),

--- a/services/mail_imports/recovery_pool.py
+++ b/services/mail_imports/recovery_pool.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from sqlmodel import Session, select
+
+from core.db import OutlookAccountLeaseModel, OutlookAccountModel, _utcnow, engine
+
+from .schemas import (
+    MailRecoveryPoolItem,
+    MailRecoveryPoolMailboxType,
+    MailRecoveryPoolRequest,
+    MailRecoveryPoolResponse,
+    MailRecoveryPoolSummary,
+)
+
+
+def resolve_mailbox_type(email: str) -> MailRecoveryPoolMailboxType:
+    domain = str(email or "").strip().lower().split("@")[-1]
+    if "hotmail" in domain:
+        return "hotmail"
+    if "outlook" in domain:
+        return "outlook"
+    return "other"
+
+
+def restore_microsoft_recovery_item(item_id: int) -> MailRecoveryPoolItem:
+    with Session(engine) as session:
+        row = session.get(OutlookAccountLeaseModel, item_id)
+        if row is None:
+            raise RuntimeError("未找到要恢复的微软邮箱记录")
+        if str(row.status or "") != "recoverable":
+            raise RuntimeError("当前仅支持恢复“可恢复”状态的微软邮箱")
+
+        existing = session.exec(
+            select(OutlookAccountModel).where(OutlookAccountModel.email == row.email)
+        ).first()
+        now = _utcnow()
+        if existing is not None:
+            existing.password = row.password
+            existing.client_id = row.client_id
+            existing.refresh_token = row.refresh_token
+            existing.enabled = True
+            existing.updated_at = now
+            session.add(existing)
+        else:
+            session.add(
+                OutlookAccountModel(
+                    email=row.email,
+                    password=row.password,
+                    client_id=row.client_id,
+                    refresh_token=row.refresh_token,
+                    enabled=True,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+
+        restored_item = MailRecoveryPoolItem(
+            id=int(row.id or 0),
+            email=str(row.email or ""),
+            mailbox_type=resolve_mailbox_type(row.email),
+            status=str(row.status or ""),
+            has_oauth=bool(row.client_id and row.refresh_token),
+            source_account_id=row.source_account_id,
+            task_attempt_id=str(row.task_attempt_id or ""),
+            last_error=str(row.last_error or ""),
+            leased_at=row.leased_at,
+            last_failed_at=row.last_failed_at,
+            updated_at=row.updated_at,
+        )
+        session.delete(row)
+        session.commit()
+        return restored_item
+
+
+def get_microsoft_recovery_pool(
+    request: MailRecoveryPoolRequest,
+) -> MailRecoveryPoolResponse:
+    with Session(engine) as session:
+        rows = session.exec(
+            select(OutlookAccountLeaseModel).order_by(
+                OutlookAccountLeaseModel.updated_at.desc(),
+                OutlookAccountLeaseModel.id.desc(),
+            )
+        ).all()
+
+    normalized_search = str(request.search or "").strip().lower()
+
+    summary = MailRecoveryPoolSummary(
+        total=len(rows),
+        leased=sum(1 for row in rows if str(row.status or "") == "leased"),
+        recoverable=sum(1 for row in rows if str(row.status or "") == "recoverable"),
+        hotmail=sum(1 for row in rows if resolve_mailbox_type(row.email) == "hotmail"),
+        outlook=sum(1 for row in rows if resolve_mailbox_type(row.email) == "outlook"),
+        other=sum(1 for row in rows if resolve_mailbox_type(row.email) == "other"),
+    )
+
+    def matches(row: OutlookAccountLeaseModel) -> bool:
+        mailbox_type = resolve_mailbox_type(row.email)
+        if request.mailbox_type != "all" and mailbox_type != request.mailbox_type:
+            return False
+        if request.status != "all" and str(row.status or "") != request.status:
+            return False
+        if not normalized_search:
+            return True
+
+        haystacks = (
+            str(row.email or "").lower(),
+            str(row.last_error or "").lower(),
+            str(row.task_attempt_id or "").lower(),
+        )
+        return any(normalized_search in value for value in haystacks)
+
+    filtered_rows = [row for row in rows if matches(row)]
+    limited_rows = filtered_rows[: request.limit]
+
+    items = [
+        MailRecoveryPoolItem(
+            id=int(row.id or 0),
+            email=str(row.email or ""),
+            mailbox_type=resolve_mailbox_type(row.email),
+            status=str(row.status or ""),
+            has_oauth=bool(row.client_id and row.refresh_token),
+            source_account_id=row.source_account_id,
+            task_attempt_id=str(row.task_attempt_id or ""),
+            last_error=str(row.last_error or ""),
+            leased_at=row.leased_at,
+            last_failed_at=row.last_failed_at,
+            updated_at=row.updated_at,
+        )
+        for row in limited_rows
+    ]
+
+    return MailRecoveryPoolResponse(
+        mailbox_type=request.mailbox_type,
+        status=request.status,
+        search=str(request.search or ""),
+        count=len(filtered_rows),
+        items=items,
+        truncated=len(filtered_rows) > request.limit,
+        summary=summary,
+    )

--- a/services/mail_imports/schemas.py
+++ b/services/mail_imports/schemas.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
 
 MailImportProviderType = Literal["applemail", "microsoft"]
+MailRecoveryPoolMailboxFilter = Literal["all", "outlook", "hotmail"]
+MailRecoveryPoolMailboxType = Literal["outlook", "hotmail", "other"]
+MailRecoveryPoolStatusFilter = Literal["all", "leased", "recoverable"]
 
 DEFAULT_PREVIEW_LIMIT = 100
 MAX_PREVIEW_LIMIT = 500
@@ -110,3 +114,51 @@ class MailImportResponse(BaseModel):
     snapshot: MailImportSnapshot
     errors: list[str] = Field(default_factory=list)
     meta: dict[str, Any] = Field(default_factory=dict)
+
+
+class MailRecoveryPoolRequest(BaseModel):
+    mailbox_type: MailRecoveryPoolMailboxFilter = "all"
+    status: MailRecoveryPoolStatusFilter = "all"
+    search: str = ""
+    limit: int = Field(
+        default=DEFAULT_PREVIEW_LIMIT,
+        ge=1,
+        le=MAX_PREVIEW_LIMIT,
+    )
+
+
+class MailRecoveryPoolItem(BaseModel):
+    id: int
+    email: str
+    mailbox_type: MailRecoveryPoolMailboxType
+    status: str
+    has_oauth: bool = False
+    source_account_id: int | None = None
+    task_attempt_id: str = ""
+    last_error: str = ""
+    leased_at: datetime | None = None
+    last_failed_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class MailRecoveryPoolSummary(BaseModel):
+    total: int = 0
+    leased: int = 0
+    recoverable: int = 0
+    hotmail: int = 0
+    outlook: int = 0
+    other: int = 0
+
+
+class MailRecoveryPoolResponse(BaseModel):
+    mailbox_type: MailRecoveryPoolMailboxFilter
+    status: MailRecoveryPoolStatusFilter
+    search: str = ""
+    count: int
+    items: list[MailRecoveryPoolItem] = Field(default_factory=list)
+    truncated: bool = False
+    summary: MailRecoveryPoolSummary = Field(default_factory=MailRecoveryPoolSummary)
+
+
+class MailRecoveryPoolRestoreRequest(BaseModel):
+    id: int = Field(ge=1)

--- a/tests/test_chatgpt_plugin.py
+++ b/tests/test_chatgpt_plugin.py
@@ -41,6 +41,19 @@ class _RequeueMailbox(_TrackingMailbox):
         self.requeued.append(account)
 
 
+class _RecoveringMailbox(_TrackingMailbox):
+    def __init__(self):
+        super().__init__()
+        self.successes = []
+        self.failures = []
+
+    def mark_account_success(self, account):
+        self.successes.append(account)
+
+    def mark_account_failure(self, account, error=None):
+        self.failures.append((account, error))
+
+
 class _FakeAdapter:
     def run(self, context):
         context.email_service.create_email()
@@ -149,6 +162,40 @@ class ChatGPTPluginTests(unittest.TestCase):
                 platform.register()
 
         self.assertEqual(mailbox.requeued, [mailbox.account])
+
+    def test_custom_provider_marks_mailbox_success_on_success(self):
+        mailbox = _RecoveringMailbox()
+        platform = ChatGPTPlatform(
+            config=RegisterConfig(extra={"chatgpt_registration_mode": "refresh_token"}),
+            mailbox=mailbox,
+        )
+        adapter = _VerificationAdapter()
+
+        with mock.patch(
+            "platforms.chatgpt.plugin.build_chatgpt_registration_mode_adapter",
+            return_value=adapter,
+        ):
+            platform.register()
+
+        self.assertEqual(mailbox.successes, [mailbox.account])
+        self.assertEqual(mailbox.failures, [])
+
+    def test_custom_provider_marks_mailbox_failure_on_failure(self):
+        mailbox = _RecoveringMailbox()
+        platform = ChatGPTPlatform(
+            config=RegisterConfig(extra={"chatgpt_registration_mode": "refresh_token"}),
+            mailbox=mailbox,
+        )
+
+        with mock.patch(
+            "platforms.chatgpt.plugin.build_chatgpt_registration_mode_adapter",
+            return_value=_FailingAdapter(),
+        ):
+            with self.assertRaises(RuntimeError):
+                platform.register()
+
+        self.assertEqual(mailbox.successes, [])
+        self.assertEqual(mailbox.failures, [(mailbox.account, "boom")])
 
 
 if __name__ == "__main__":

--- a/tests/test_chatgpt_register.py
+++ b/tests/test_chatgpt_register.py
@@ -224,6 +224,61 @@ class RefreshTokenRegistrationEngineTests(unittest.TestCase):
         self.assertEqual(call_args[0].args[0], "user1@example.com")
         self.assertEqual(call_args[1].args[0], "user2@example.com")
 
+    @mock.patch("platforms.chatgpt.refresh_token_registration_engine.OAuthManager")
+    @mock.patch("platforms.chatgpt.refresh_token_registration_engine.OAuthClient")
+    @mock.patch(
+        "platforms.chatgpt.refresh_token_registration_engine.ChatGPTClient"
+    )
+    def test_run_enables_cached_code_retry_for_post_register_new_oauth_session(
+        self,
+        mock_register_client_cls,
+        mock_oauth_client_cls,
+        mock_oauth_manager_cls,
+    ):
+        register_client = mock.Mock()
+        register_client.ua = "UA"
+        register_client.sec_ch_ua = '"Chromium";v="136"'
+        register_client.impersonate = "chrome136"
+        register_client.register_complete_flow.return_value = (
+            True,
+            "registration complete",
+        )
+        mock_register_client_cls.return_value = register_client
+
+        oauth_client = mock.Mock()
+        oauth_client.last_error = ""
+        oauth_client.last_workspace_id = "ws-1"
+        oauth_client.login_and_get_tokens.return_value = {
+            "access_token": "at",
+            "refresh_token": "rt",
+            "id_token": "id-token",
+            "account_id": "acct-1",
+        }
+        oauth_client._decode_oauth_session_cookie.return_value = {
+            "workspaces": [{"id": "ws-1"}]
+        }
+        oauth_client._get_cookie_value.return_value = "session-1"
+        mock_oauth_client_cls.return_value = oauth_client
+
+        oauth_manager = mock.Mock()
+        oauth_manager.extract_account_info.return_value = {
+            "email": "user@example.com",
+            "account_id": "acct-1",
+        }
+        mock_oauth_manager_cls.return_value = oauth_manager
+
+        engine = self._make_engine(browser_mode="protocol")
+        result = engine.run()
+
+        self.assertTrue(result.success)
+        login_kwargs = oauth_client.login_and_get_tokens.call_args.kwargs
+        self.assertTrue(login_kwargs["force_new_browser"])
+        self.assertEqual(
+            login_kwargs["login_source"],
+            "post_register_workspace_continue",
+        )
+        self.assertTrue(login_kwargs["allow_cached_code_retry"])
+
 
 class AccessTokenOnlyRegistrationEngineTests(unittest.TestCase):
     def test_run_does_not_retry_after_http_400_registration_failure(self):
@@ -379,6 +434,37 @@ class OAuthClientPasswordlessTests(unittest.TestCase):
         self.assertEqual(tokens["access_token"], "at")
         follow_state.assert_called_once()
         handle_phone.assert_not_called()
+
+    def test_login_and_get_tokens_forwards_cached_code_retry_to_otp_handler(self):
+        client = self._make_client()
+        email_otp_state = FlowState(
+            page_type="email_otp_verification",
+            continue_url="https://auth.openai.com/email-verification",
+            current_url="https://auth.openai.com/email-verification",
+        )
+        consent_state = FlowState(
+            page_type="consent",
+            continue_url="https://auth.openai.com/sign-in-with-chatgpt/codex/consent",
+            current_url="https://auth.openai.com/sign-in-with-chatgpt/codex/consent",
+        )
+
+        with mock.patch.object(client, "_bootstrap_oauth_session", return_value="https://auth.openai.com/log-in"), \
+            mock.patch.object(client, "_submit_authorize_continue", return_value=email_otp_state), \
+            mock.patch.object(client, "_handle_otp_verification", return_value=consent_state) as handle_otp, \
+            mock.patch.object(client, "_oauth_submit_workspace_and_org", return_value=("auth-code", None)), \
+            mock.patch.object(client, "_exchange_code_for_tokens", return_value={"access_token": "at"}):
+            tokens = client.login_and_get_tokens(
+                "user@example.com",
+                "Secret123!",
+                "device-fixed",
+                skymail_client=mock.Mock(),
+                prefer_passwordless_login=True,
+                allow_phone_verification=False,
+                allow_cached_code_retry=True,
+            )
+
+        self.assertEqual(tokens["access_token"], "at")
+        self.assertTrue(handle_otp.call_args.kwargs["allow_cached_code_retry"])
 
     def test_login_and_get_tokens_uses_canonical_consent_url_when_state_is_add_phone(self):
         client = self._make_client()

--- a/tests/test_chatgpt_register.py
+++ b/tests/test_chatgpt_register.py
@@ -14,6 +14,9 @@ sys.modules.setdefault("smstome_tool", smstome_tool_stub)
 
 from platforms.chatgpt.oauth_client import OAuthClient
 from platforms.chatgpt.chatgpt_client import ChatGPTClient
+from platforms.chatgpt.access_token_only_registration_engine import (
+    AccessTokenOnlyRegistrationEngine,
+)
 from platforms.chatgpt.refresh_token_registration_engine import (
     RefreshTokenRegistrationEngine,
 )
@@ -220,6 +223,47 @@ class RefreshTokenRegistrationEngineTests(unittest.TestCase):
         call_args = oauth_client.signup_and_get_tokens.call_args_list
         self.assertEqual(call_args[0].args[0], "user1@example.com")
         self.assertEqual(call_args[1].args[0], "user2@example.com")
+
+
+class AccessTokenOnlyRegistrationEngineTests(unittest.TestCase):
+    def test_run_does_not_retry_after_http_400_registration_failure(self):
+        class RotatingEmailService:
+            service_type = type("ST", (), {"value": "dummy"})()
+
+            def __init__(self):
+                self.created = []
+
+            def create_email(self):
+                email = f"user{len(self.created) + 1}@example.com"
+                self.created.append(email)
+                return {"email": email, "service_id": email}
+
+            def get_verification_code(self, **kwargs):
+                return "123456"
+
+        email_service = RotatingEmailService()
+        client = mock.Mock()
+        client.register_complete_flow.return_value = (
+            False,
+            "注册失败: 400 - rate limited",
+        )
+
+        with mock.patch(
+            "platforms.chatgpt.access_token_only_registration_engine.ChatGPTClient",
+            return_value=client,
+        ):
+            engine = AccessTokenOnlyRegistrationEngine(
+                email_service=email_service,
+                proxy_url="http://127.0.0.1:7890",
+                callback_logger=lambda msg: None,
+                max_retries=3,
+            )
+            result = engine.run()
+
+        self.assertFalse(result.success)
+        self.assertIn("400", result.error_message)
+        self.assertEqual(email_service.created, ["user1@example.com"])
+        client.register_complete_flow.assert_called_once()
 
 
 class OAuthClientPasswordlessTests(unittest.TestCase):

--- a/tests/test_mail_imports_service.py
+++ b/tests/test_mail_imports_service.py
@@ -6,7 +6,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from sqlmodel import SQLModel, create_engine
+from sqlmodel import Session, SQLModel, create_engine, select
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -199,6 +199,164 @@ class MailImportServiceTests(unittest.TestCase):
                     self.assertEqual(response.snapshot.count, 1)
                     self.assertEqual(response.snapshot.items[0].email, "first@outlook.com")
                     self.assertIn("service abuse mode", response.errors[0])
+            finally:
+                test_engine.dispose()
+
+    def test_microsoft_snapshot_only_shows_available_accounts(self):
+        from core.db import OutlookAccountLeaseModel, OutlookAccountModel
+        from services.mail_imports.providers import MicrosoftMailImportStrategy
+        from services.mail_imports.schemas import MailImportSnapshotRequest
+
+        strategy = MicrosoftMailImportStrategy()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_engine = create_engine(f"sqlite:///{Path(tmp_dir) / 'mail-imports.db'}")
+            SQLModel.metadata.create_all(test_engine)
+
+            try:
+                with Session(test_engine) as session:
+                    session.add(
+                        OutlookAccountModel(
+                            email="available@outlook.com",
+                            password="password",
+                            client_id="client-a",
+                            refresh_token="refresh-a",
+                            enabled=True,
+                        )
+                    )
+                    session.add(
+                        OutlookAccountModel(
+                            email="disabled@outlook.com",
+                            password="password",
+                            client_id="client-b",
+                            refresh_token="refresh-b",
+                            enabled=False,
+                        )
+                    )
+                    session.add(
+                        OutlookAccountLeaseModel(
+                            email="recoverable@hotmail.com",
+                            password="password",
+                            client_id="client-c",
+                            refresh_token="refresh-c",
+                            status="recoverable",
+                            last_error="token_exchange failed",
+                        )
+                    )
+                    session.commit()
+
+                with patch("services.mail_imports.providers.engine", test_engine):
+                    snapshot = strategy.get_snapshot(
+                        MailImportSnapshotRequest(
+                            type="microsoft",
+                            preview_limit=10,
+                        )
+                    )
+
+                self.assertEqual(snapshot.count, 1)
+                self.assertEqual([item.email for item in snapshot.items], ["available@outlook.com"])
+            finally:
+                test_engine.dispose()
+
+    def test_recovery_pool_filters_hotmail_recoverable_items(self):
+        from core.db import OutlookAccountLeaseModel
+        from services.mail_imports.recovery_pool import get_microsoft_recovery_pool
+        from services.mail_imports.schemas import MailRecoveryPoolRequest
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_engine = create_engine(f"sqlite:///{Path(tmp_dir) / 'recovery-pool.db'}")
+            SQLModel.metadata.create_all(test_engine)
+
+            try:
+                with Session(test_engine) as session:
+                    session.add(
+                        OutlookAccountLeaseModel(
+                            email="recoverable@hotmail.com",
+                            password="password",
+                            client_id="client-a",
+                            refresh_token="refresh-a",
+                            status="recoverable",
+                            task_attempt_id="attempt-1",
+                            last_error="token_exchange failed",
+                        )
+                    )
+                    session.add(
+                        OutlookAccountLeaseModel(
+                            email="leased@outlook.com",
+                            password="password",
+                            client_id="client-b",
+                            refresh_token="refresh-b",
+                            status="leased",
+                            task_attempt_id="attempt-2",
+                        )
+                    )
+                    session.add(
+                        OutlookAccountLeaseModel(
+                            email="other@live.com",
+                            password="password",
+                            client_id="client-c",
+                            refresh_token="refresh-c",
+                            status="recoverable",
+                            task_attempt_id="attempt-3",
+                        )
+                    )
+                    session.commit()
+
+                with patch("services.mail_imports.recovery_pool.engine", test_engine):
+                    snapshot = get_microsoft_recovery_pool(
+                        MailRecoveryPoolRequest(
+                            mailbox_type="hotmail",
+                            status="recoverable",
+                            limit=10,
+                        )
+                    )
+
+                self.assertEqual(snapshot.count, 1)
+                self.assertEqual([item.email for item in snapshot.items], ["recoverable@hotmail.com"])
+                self.assertEqual(snapshot.summary.total, 3)
+                self.assertEqual(snapshot.summary.recoverable, 2)
+                self.assertEqual(snapshot.summary.leased, 1)
+                self.assertEqual(snapshot.summary.hotmail, 1)
+                self.assertEqual(snapshot.summary.outlook, 1)
+                self.assertEqual(snapshot.summary.other, 1)
+            finally:
+                test_engine.dispose()
+
+    def test_restore_recovery_item_moves_mailbox_back_to_available_pool(self):
+        from core.db import OutlookAccountLeaseModel, OutlookAccountModel
+        from services.mail_imports.recovery_pool import restore_microsoft_recovery_item
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_engine = create_engine(f"sqlite:///{Path(tmp_dir) / 'restore-recovery.db'}")
+            SQLModel.metadata.create_all(test_engine)
+
+            try:
+                with Session(test_engine) as session:
+                    session.add(
+                        OutlookAccountLeaseModel(
+                            email="restore@hotmail.com",
+                            password="password",
+                            client_id="client-a",
+                            refresh_token="refresh-a",
+                            status="recoverable",
+                            task_attempt_id="attempt-restore",
+                            last_error="token_exchange failed",
+                        )
+                    )
+                    session.commit()
+                    lease = session.exec(select(OutlookAccountLeaseModel)).first()
+
+                with patch("services.mail_imports.recovery_pool.engine", test_engine):
+                    restored = restore_microsoft_recovery_item(int(lease.id or 0))
+
+                self.assertEqual(restored.email, "restore@hotmail.com")
+                self.assertEqual(restored.status, "recoverable")
+
+                with Session(test_engine) as session:
+                    available = session.exec(select(OutlookAccountModel)).all()
+                    remaining = session.exec(select(OutlookAccountLeaseModel)).all()
+
+                self.assertEqual([item.email for item in available], ["restore@hotmail.com"])
+                self.assertEqual(len(remaining), 0)
             finally:
                 test_engine.dispose()
 

--- a/tests/test_outlook_mailbox_oauth.py
+++ b/tests/test_outlook_mailbox_oauth.py
@@ -1,7 +1,10 @@
 import unittest
 from unittest import mock
 
+from sqlmodel import Session, SQLModel, create_engine, select
+
 from core.base_mailbox import MailboxAccount, OutlookMailbox, create_mailbox
+from core.db import OutlookAccountLeaseModel, OutlookAccountModel
 
 
 class _FakeResponse:
@@ -236,6 +239,102 @@ class OutlookMailboxOAuthTests(unittest.TestCase):
             "https://outlook.office.com/.default offline_access",
             attempted_scopes,
         )
+
+    def test_get_email_moves_account_into_recovery_pool(self):
+        mailbox = OutlookMailbox()
+        test_engine = create_engine("sqlite://")
+        SQLModel.metadata.create_all(test_engine)
+
+        try:
+            with Session(test_engine) as session:
+                session.add(
+                    OutlookAccountModel(
+                        email="lease-demo@outlook.com",
+                        password="password",
+                        client_id="client-id",
+                        refresh_token="refresh-token",
+                    )
+                )
+                session.commit()
+
+            with mock.patch("core.db.engine", test_engine):
+                account = mailbox.get_email()
+
+            self.assertEqual(account.email, "lease-demo@outlook.com")
+            self.assertTrue(account.extra.get("outlook_lease_id"))
+
+            with Session(test_engine) as session:
+                available = session.exec(select(OutlookAccountModel)).all()
+                leased = session.exec(select(OutlookAccountLeaseModel)).all()
+
+            self.assertEqual(len(available), 0)
+            self.assertEqual(len(leased), 1)
+            self.assertEqual(leased[0].email, "lease-demo@outlook.com")
+            self.assertEqual(leased[0].status, "leased")
+        finally:
+            test_engine.dispose()
+
+    def test_mark_account_failure_keeps_account_in_recovery_pool(self):
+        mailbox = OutlookMailbox()
+        test_engine = create_engine("sqlite://")
+        SQLModel.metadata.create_all(test_engine)
+
+        try:
+            with Session(test_engine) as session:
+                session.add(
+                    OutlookAccountModel(
+                        email="failed-demo@outlook.com",
+                        password="password",
+                        client_id="client-id",
+                        refresh_token="refresh-token",
+                    )
+                )
+                session.commit()
+
+            with mock.patch("core.db.engine", test_engine):
+                account = mailbox.get_email()
+                mailbox.mark_account_failure(account, error="token_exchange failed")
+
+            with Session(test_engine) as session:
+                available = session.exec(select(OutlookAccountModel)).all()
+                leased = session.exec(select(OutlookAccountLeaseModel)).all()
+
+            self.assertEqual(len(available), 0)
+            self.assertEqual(len(leased), 1)
+            self.assertEqual(leased[0].status, "recoverable")
+            self.assertEqual(leased[0].last_error, "token_exchange failed")
+        finally:
+            test_engine.dispose()
+
+    def test_mark_account_success_clears_recovery_record(self):
+        mailbox = OutlookMailbox()
+        test_engine = create_engine("sqlite://")
+        SQLModel.metadata.create_all(test_engine)
+
+        try:
+            with Session(test_engine) as session:
+                session.add(
+                    OutlookAccountModel(
+                        email="success-demo@outlook.com",
+                        password="password",
+                        client_id="client-id",
+                        refresh_token="refresh-token",
+                    )
+                )
+                session.commit()
+
+            with mock.patch("core.db.engine", test_engine):
+                account = mailbox.get_email()
+                mailbox.mark_account_success(account)
+
+            with Session(test_engine) as session:
+                available = session.exec(select(OutlookAccountModel)).all()
+                leased = session.exec(select(OutlookAccountLeaseModel)).all()
+
+            self.assertEqual(len(available), 0)
+            self.assertEqual(len(leased), 0)
+        finally:
+            test_engine.dispose()
 
 
 if __name__ == "__main__":

--- a/tests/test_outlook_mailbox_oauth.py
+++ b/tests/test_outlook_mailbox_oauth.py
@@ -205,6 +205,66 @@ class OutlookMailboxOAuthTests(unittest.TestCase):
         self.assertTrue(any("/me/mailFolders/deleteditems/messages" in url for url in requested_urls))
 
     @mock.patch("requests.post")
+    @mock.patch("requests.request")
+    def test_wait_for_code_skips_graph_messages_older_than_otp_sent_at(self, mock_request, mock_post):
+        mailbox = OutlookMailbox(token_endpoint="https://token.example.test")
+        mailbox._graph_folder_names = ["inbox"]
+        account = MailboxAccount(
+            email="demo@outlook.com",
+            extra={
+                "client_id": "client-id",
+                "refresh_token": "refresh-token",
+            },
+        )
+        mock_post.return_value = _FakeResponse(
+            200,
+            payload={"access_token": "graph-token", "expires_in": 3600},
+            text='{"access_token":"graph-token","expires_in":3600}',
+        )
+        mock_request.side_effect = [
+            _FakeResponse(
+                200,
+                payload={
+                    "value": [
+                        {
+                            "id": "message-old",
+                            "subject": "OpenAI verification code",
+                            "bodyPreview": "Your verification code is 111111",
+                            "receivedDateTime": "1970-01-01T00:01:00+00:00",
+                        }
+                    ]
+                },
+            ),
+            _FakeResponse(
+                200,
+                payload={
+                    "value": [
+                        {
+                            "id": "message-new",
+                            "subject": "OpenAI verification code",
+                            "bodyPreview": "Your verification code is 222222",
+                            "receivedDateTime": "1970-01-01T00:05:00+00:00",
+                        }
+                    ]
+                },
+            ),
+        ]
+
+        def run_two_polls(*, poll_once, **kwargs):
+            first = poll_once()
+            if first:
+                return first
+            second = poll_once()
+            if second:
+                return second
+            raise TimeoutError("expected a fresh OTP")
+
+        with mock.patch.object(mailbox, "_run_polling_wait", side_effect=run_two_polls):
+            code = mailbox.wait_for_code(account, timeout=5, otp_sent_at=180)
+
+        self.assertEqual(code, "222222")
+
+    @mock.patch("requests.post")
     def test_fetch_oauth_token_returns_empty_when_probe_gets_malformed_json_on_2xx(self, mock_post):
         mailbox = OutlookMailbox(token_endpoint="https://token.example.test")
         mock_post.side_effect = [

--- a/tests/test_proxy_pool.py
+++ b/tests/test_proxy_pool.py
@@ -1,0 +1,85 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from core.proxy_pool import ProxyPool
+
+
+class _FakeExecResult:
+    def __init__(self, proxy):
+        self._proxy = proxy
+
+    def first(self):
+        return self._proxy
+
+
+class _FakeSession:
+    def __init__(self, proxy):
+        self._proxy = proxy
+        self.added = None
+        self.committed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def exec(self, _query):
+        return _FakeExecResult(self._proxy)
+
+    def add(self, obj):
+        self.added = obj
+
+    def commit(self):
+        self.committed = True
+
+
+class ProxyPoolTests(unittest.TestCase):
+    def test_report_fail_auto_disables_proxy_when_enabled(self):
+        proxy = SimpleNamespace(
+            url="http://proxy.local:8080",
+            success_count=0,
+            fail_count=4,
+            is_active=True,
+            last_checked=None,
+        )
+        fake_session = _FakeSession(proxy)
+
+        with (
+            mock.patch("core.proxy_pool.Session", return_value=fake_session),
+            mock.patch("core.proxy_pool.config_store.get", return_value="1"),
+        ):
+            ProxyPool().report_fail(proxy.url)
+
+        self.assertEqual(proxy.fail_count, 5)
+        self.assertFalse(proxy.is_active)
+        self.assertIsNotNone(proxy.last_checked)
+        self.assertIs(fake_session.added, proxy)
+        self.assertTrue(fake_session.committed)
+
+    def test_report_fail_does_not_disable_proxy_when_switch_is_off(self):
+        proxy = SimpleNamespace(
+            url="http://proxy.local:8080",
+            success_count=0,
+            fail_count=4,
+            is_active=True,
+            last_checked=None,
+        )
+        fake_session = _FakeSession(proxy)
+
+        with (
+            mock.patch("core.proxy_pool.Session", return_value=fake_session),
+            mock.patch("core.proxy_pool.config_store.get", return_value="0"),
+        ):
+            ProxyPool().report_fail(proxy.url)
+
+        self.assertEqual(proxy.fail_count, 5)
+        self.assertTrue(proxy.is_active)
+        self.assertIsNotNone(proxy.last_checked)
+        self.assertIs(fake_session.added, proxy)
+        self.assertTrue(fake_session.committed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_register_task_controls.py
+++ b/tests/test_register_task_controls.py
@@ -1,3 +1,5 @@
+import io
+import sys
 import unittest
 from unittest.mock import patch
 
@@ -53,6 +55,27 @@ class _FakePlatform(BasePlatform):
         return True
 
 
+class _EmojiLoggingPlatform(BasePlatform):
+    name = "fake"
+    display_name = "Fake"
+
+    def __init__(self, config=None, mailbox=None):
+        super().__init__(config)
+        self.mailbox = mailbox
+
+    def register(self, email: str, password: str = None) -> Account:
+        if self._log_fn:
+            self._log_fn("\u2705 OAuth 注册成功")
+        return Account(
+            platform="fake",
+            email="emoji@example.com",
+            password=password or "pw",
+        )
+
+    def check_valid(self, account: Account) -> bool:
+        return True
+
+
 class _FakeChatGPTWorkspacePlatform(BasePlatform):
     name = "chatgpt"
     display_name = "ChatGPT"
@@ -79,6 +102,23 @@ class _FakeChatGPTWorkspacePlatform(BasePlatform):
 
     def check_valid(self, account: Account) -> bool:
         return True
+
+
+class _FailingGbkStdout(io.TextIOBase):
+    encoding = "gbk"
+
+    def __init__(self):
+        super().__init__()
+        self.buffer = io.BytesIO()
+
+    def write(self, text):
+        payload = str(text)
+        encoded = payload.encode(self.encoding)
+        self.buffer.write(encoded)
+        return len(payload)
+
+    def flush(self):
+        return None
 
 
 class RegisterTaskControlFlowTests(unittest.TestCase):
@@ -146,6 +186,29 @@ class RegisterTaskControlFlowTests(unittest.TestCase):
 
         self.assertIn("workspace进度: 1/2", joined_logs)
         self.assertIn("workspace进度: 2/2", joined_logs)
+
+
+    def test_emoji_log_does_not_turn_success_into_failure_under_gbk_stdout(self):
+        task_id = "task-gbk-emoji-log"
+        req = self._build_request()
+        _create_task_record(task_id, req, "manual", None)
+        fake_stdout = _FailingGbkStdout()
+
+        with (
+            patch("core.registry.get", return_value=_EmojiLoggingPlatform),
+            patch("core.base_mailbox.create_mailbox", return_value=_FakeMailbox()),
+            patch("core.db.save_account", side_effect=lambda account: account),
+            patch("api.tasks._save_task_log"),
+            patch.object(sys, "stdout", fake_stdout),
+        ):
+            _run_register(task_id, req)
+
+        snapshot = _task_store.snapshot(task_id)
+        joined_logs = "\n".join(snapshot["logs"])
+
+        self.assertEqual(snapshot["status"], "done")
+        self.assertEqual(snapshot["success"], 1)
+        self.assertIn("\u2705 OAuth 注册成功", joined_logs)
 
 
 if __name__ == "__main__":

--- a/tests/test_register_task_controls.py
+++ b/tests/test_register_task_controls.py
@@ -1,5 +1,7 @@
 import io
 import sys
+import threading
+import time
 import unittest
 from unittest.mock import patch
 
@@ -98,6 +100,46 @@ class _FakeChatGPTWorkspacePlatform(BasePlatform):
             email=f"user{index}@example.com",
             password=password or "pw",
             extra={"workspace_id": f"ws-{index}"},
+        )
+
+    def check_valid(self, account: Account) -> bool:
+        return True
+
+
+class _AutoPause400Platform(BasePlatform):
+    name = "fake"
+    display_name = "Fake"
+
+    _counter = 0
+    _counter_lock = threading.Lock()
+
+    def __init__(self, config=None, mailbox=None):
+        super().__init__(config)
+        self.mailbox = mailbox
+
+    @classmethod
+    def reset_counter(cls):
+        with cls._counter_lock:
+            cls._counter = 0
+
+    def register(self, email: str, password: str = None) -> Account:
+        with type(self)._counter_lock:
+            type(self)._counter += 1
+            current = type(self)._counter
+
+        if current == 1:
+            time.sleep(0.05)
+            raise RuntimeError("注册失败: 400 - rate limited")
+
+        deadline = time.time() + 2
+        while time.time() < deadline:
+            self._task_control.checkpoint()
+            time.sleep(0.01)
+
+        return Account(
+            platform="fake",
+            email="should-not-complete@example.com",
+            password=password or "pw",
         )
 
     def check_valid(self, account: Account) -> bool:
@@ -209,6 +251,60 @@ class RegisterTaskControlFlowTests(unittest.TestCase):
         self.assertEqual(snapshot["status"], "done")
         self.assertEqual(snapshot["success"], 1)
         self.assertIn("\u2705 OAuth 注册成功", joined_logs)
+
+    def test_http_400_auto_pauses_entire_task_and_logs_risk_message(self):
+        task_id = "task-auto-pause-http-400"
+        req = self._build_request(count=2, concurrency=2)
+        _create_task_record(task_id, req, "manual", None)
+        _AutoPause400Platform.reset_counter()
+
+        with (
+            patch("core.registry.get", return_value=_AutoPause400Platform),
+            patch("core.base_mailbox.create_mailbox", return_value=_FakeMailbox()),
+            patch("core.db.save_account", side_effect=lambda account: account),
+            patch("api.tasks._save_task_log"),
+        ):
+            _run_register(task_id, req)
+
+        snapshot = _task_store.snapshot(task_id)
+        joined_logs = "\n".join(snapshot["logs"])
+
+        self.assertEqual(snapshot["status"], "paused")
+        self.assertEqual(snapshot["success"], 0)
+        self.assertEqual(snapshot["skipped"], 0)
+        self.assertEqual(len(snapshot["errors"]), 1)
+        self.assertIn("400", snapshot["errors"][0])
+        self.assertTrue(snapshot["control"]["pause_requested"])
+        self.assertIn("可能触发风控", snapshot["control"]["pause_reason"])
+        self.assertIn("可能触发风控", joined_logs)
+
+    def test_http_400_auto_pause_can_be_disabled_for_register_task(self):
+        task_id = "task-auto-pause-http-400-disabled"
+        req = self._build_request(
+            count=2,
+            concurrency=2,
+            auto_pause_on_http_400=False,
+        )
+        _create_task_record(task_id, req, "manual", None)
+        _AutoPause400Platform.reset_counter()
+
+        with (
+            patch("core.registry.get", return_value=_AutoPause400Platform),
+            patch("core.base_mailbox.create_mailbox", return_value=_FakeMailbox()),
+            patch("core.db.save_account", side_effect=lambda account: account),
+            patch("api.tasks._save_task_log"),
+        ):
+            _run_register(task_id, req)
+
+        snapshot = _task_store.snapshot(task_id)
+        joined_logs = "\n".join(snapshot["logs"])
+
+        self.assertEqual(snapshot["status"], "done")
+        self.assertEqual(snapshot["success"], 1)
+        self.assertEqual(snapshot["skipped"], 0)
+        self.assertEqual(len(snapshot["errors"]), 1)
+        self.assertFalse(snapshot["control"]["pause_requested"])
+        self.assertNotIn("[PAUSE]", joined_logs)
 
 
 if __name__ == "__main__":

--- a/tests/test_task_runtime.py
+++ b/tests/test_task_runtime.py
@@ -1,6 +1,7 @@
 import unittest
 
 from core.task_runtime import (
+    PauseTaskRequested,
     RegisterTaskControl,
     RegisterTaskStore,
     SkipCurrentAttemptRequested,
@@ -28,6 +29,20 @@ class RegisterTaskControlTests(unittest.TestCase):
             control.checkpoint()
         with self.assertRaises(StopTaskRequested):
             control.checkpoint()
+
+    def test_pause_request_is_sticky_and_preserves_reason(self):
+        control = RegisterTaskControl()
+
+        first_request = control.request_pause("疑似风控")
+        second_request = control.request_pause("另一个原因")
+
+        self.assertTrue(first_request)
+        self.assertFalse(second_request)
+        self.assertTrue(control.is_pause_requested())
+
+        with self.assertRaises(PauseTaskRequested) as exc_info:
+            control.checkpoint()
+        self.assertIn("疑似风控", str(exc_info.exception))
 
     def test_skip_current_targets_only_active_attempts_in_multithread_mode(self):
         control = RegisterTaskControl()
@@ -78,6 +93,40 @@ class RegisterTaskStoreTests(unittest.TestCase):
         self.assertEqual(
             snapshot["control"]["pending_skip_requests"],
             1,
+        )
+
+    def test_snapshot_contains_pause_fields(self):
+        store = RegisterTaskStore()
+        task_id = "task-runtime-pause"
+
+        store.create(
+            task_id,
+            platform="chatgpt",
+            total=1,
+            source="manual",
+        )
+        control_snapshot = store.request_pause(task_id, "检测到 HTTP 400，疑似风控")
+        store.finish(
+            task_id,
+            status="paused",
+            success=0,
+            skipped=0,
+            errors=["注册失败: 400 - rate limited"],
+            error="检测到 HTTP 400，疑似风控",
+        )
+
+        snapshot = store.snapshot(task_id)
+
+        self.assertTrue(control_snapshot["pause_requested"])
+        self.assertEqual(
+            control_snapshot["pause_reason"],
+            "检测到 HTTP 400，疑似风控",
+        )
+        self.assertEqual(snapshot["status"], "paused")
+        self.assertTrue(snapshot["control"]["pause_requested"])
+        self.assertEqual(
+            snapshot["control"]["pause_reason"],
+            "检测到 HTTP 400，疑似风控",
         )
 
 


### PR DESCRIPTION
## 改动概览

这个 PR 现在包含当前分支上的 3 个相关提交：`3cf45e6`、`0f84bc0`、`9bebd8d`。

### 1. 修复 Windows / GBK 控制台日志误伤任务结果
- 为任务日志输出增加 Unicode 安全兜底，避免 `✅` 这类字符在 `gbk` 编码下触发 `UnicodeEncodeError`。
- 避免“注册实际成功，但因为控制台打印失败而被记成失败”的情况。
- 补充对应回归测试。

### 2. 增加微软邮箱恢复池与风险控制开关
- 为微软 / Hotmail 邮箱增加恢复池机制，注册失败或已注册但后续取 token 失败的邮箱不再直接丢失。
- 增加恢复池页面、恢复接口与相关测试。
- 为注册任务增加风控暂停开关，并补齐平台管理中的相关入口。
- 为代理池增加“是否自动禁用”的配置开关，保留现有逻辑但让行为可配置。

### 3. 提升 ChatGPT 注册后接力登录的 OTP 恢复能力
- 在“注册成功但未停在 `about_you`，随后新开 OAuth session”这条真实链路上，允许优先复用最近一次成功验证码。
- 递归进入 `add_phone_continue` 后继续保留这项能力，而不是重新把刚刚用过的验证码排除掉。
- Microsoft / Outlook 邮箱收信增加 `otp_sent_at` 过滤，避免 Graph / IMAP 把旧邮件里的历史验证码反复当成新验证码消费。
- 补充针对 OAuth 透传和 Outlook 旧邮件过滤的回归测试。

## 这些改动具体改善了什么

对于 `[stage=authorize_continue] 无法获取 sentinel token (authorize_continue)`、无法访问首页、Cloudflare / 页面加载异常，以及后续 workspace / callback 接续失败这类非致命错误，改动后的行为更可恢复：

- 邮箱不会因为一次中断就白白消耗掉，而是可以保留在恢复池中，后续继续恢复。
- 对于 Hotmail 这类“注册阶段已经收到验证码，但后续登录阶段不一定再发一封新验证码”的场景，恢复流程现在会优先尝试复用最近一次验证码，而不是无限轮询等待新邮件。
- 这样即使第一次是在 `authorize_continue`、首页访问或 workspace 接续等后续环节失败，邮箱依然有机会在后续恢复流程中成功拿到 token。

实测使用 `rzvkrdp0579@hotmail.com` 做恢复探针时：
- 注册阶段收到验证码并完成验证。
- 登录阶段成功复用了同一轮验证码。
- `/email-otp/validate` 成功通过，流程推进到了 `add_phone`。

这说明阻塞点已经从“邮箱轮询 / 验证码拿不到”前移到了更后面的 `add_phone / workspace` 阶段，OTP 接力恢复这一段已经被打通。

## 验证

- `python -m pytest tests/test_chatgpt_register.py -k "post_register_new_oauth_session or forwards_cached_code_retry" -q`
- 云服务器上对 `rzvkrdp0579@hotmail.com` 做了实际恢复探针，确认 `allow_cached_code_retry` 生效并成功通过 OTP 校验阶段。
