### PR TITLE
fix(cpa): local CLIProxy defaults and SQLite fallback

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -134,6 +134,10 @@ def get_config():
         all_cfg["applemail_mailboxes"] = "INBOX,Junk"
     if not all_cfg.get("outlook_backend"):
         all_cfg["outlook_backend"] = "graph"
+    if not all_cfg.get("cliproxyapi_base_url"):
+        all_cfg["cliproxyapi_base_url"] = "http://localhost:8317"
+    if not all_cfg.get("cliproxyapi_management_key"):
+        all_cfg["cliproxyapi_management_key"] = "islam"
     if not all_cfg.get("gptmail_base_url"):
         all_cfg["gptmail_base_url"] = "https://mail.chatgpt.org.uk"
     if not all_cfg.get("luckmail_base_url"):

--- a/platforms/chatgpt/cpa_upload.py
+++ b/platforms/chatgpt/cpa_upload.py
@@ -154,6 +154,36 @@ def _get_config_value(key: str) -> str:
         return ""
 
 
+def _get_cpa_default_api_url() -> str:
+    return (
+        _get_config_value("cpa_api_url")
+        or _get_config_value("cliproxyapi_base_url")
+        or "http://127.0.0.1:8317"
+    ).strip()
+
+
+def _get_cpa_default_api_key() -> str:
+    return (
+        _get_config_value("cpa_api_key")
+        or _get_config_value("cliproxyapi_management_key")
+        or "islam"
+    ).strip()
+
+
+def _fallback_refresh_token(*, email: str, account_id: str, session_token: str, access_token: str) -> str:
+    """
+    codex-auth 的 CPA 导入要求 refresh_token 非空。
+    对于 access-token-only 账号，优先使用 session_token，再退到一个稳定的占位值。
+    """
+    for candidate in (session_token, access_token):
+        value = str(candidate or "").strip()
+        if value:
+            return value
+
+    seed = str(email or account_id or "codex").strip() or "codex"
+    return f"refresh-{seed}"
+
+
 def generate_token_json(account) -> dict:
     """
     生成 CPA 格式的 Token JSON。
@@ -163,6 +193,7 @@ def generate_token_json(account) -> dict:
     email = getattr(account, "email", "")
     access_token = getattr(account, "access_token", "")
     refresh_token = getattr(account, "refresh_token", "")
+    session_token = getattr(account, "session_token", "")
     id_token = getattr(account, "id_token", "")
     if access_token and not id_token:
         id_token = _build_compat_id_token(access_token=access_token, email=email)
@@ -188,7 +219,12 @@ def generate_token_json(account) -> dict:
         "account_id": account_id,
         "access_token": access_token,
         "last_refresh": now.strftime("%Y-%m-%dT%H:%M:%S+08:00"),
-        "refresh_token": refresh_token,
+        "refresh_token": refresh_token or _fallback_refresh_token(
+            email=email,
+            account_id=account_id,
+            session_token=session_token,
+            access_token=access_token,
+        ),
     }
 
 
@@ -201,9 +237,9 @@ def upload_to_cpa(
     """上传单个账号到 CPA 管理平台（不走代理）。
     api_url / api_key 为空时自动从 ConfigStore 读取。"""
     if not api_url:
-        api_url = _get_config_value("cpa_api_url")
+        api_url = _get_cpa_default_api_url()
     if not api_key:
-        api_key = _get_config_value("cpa_api_key")
+        api_key = _get_cpa_default_api_key()
     if not api_url:
         return False, "CPA API URL 未配置"
 

--- a/services/cliproxyapi_sync.py
+++ b/services/cliproxyapi_sync.py
@@ -9,10 +9,14 @@ import time
 from datetime import datetime, timezone
 from typing import Any, Optional
 
+from sqlmodel import Session, select
+
+from core.db import AccountModel, engine
 from platforms.chatgpt.status_probe import CODEX_USER_AGENT, extract_chatgpt_account_id
 from services.chatgpt_account_state import is_account_deactivated_message
 
 DEFAULT_CLIPROXYAPI_BASE_URL = "http://127.0.0.1:8317"
+DEFAULT_CLIPROXYAPI_MANAGEMENT_KEY = "islam"
 SYNC_RETRY_ATTEMPTS = 3
 SYNC_RETRY_DELAY_SECONDS = 0.4
 BATCH_PROBE_DELAY_SECONDS = 0.12
@@ -39,7 +43,7 @@ def _base_url(api_url: str | None = None) -> str:
 
 
 def _api_key(api_key: str | None = None) -> str:
-    return str(api_key or _get_config_value("cliproxyapi_management_key", "cliproxyapi") or "cliproxyapi").strip()
+    return str(api_key or _get_config_value("cliproxyapi_management_key", DEFAULT_CLIPROXYAPI_MANAGEMENT_KEY) or DEFAULT_CLIPROXYAPI_MANAGEMENT_KEY).strip()
 
 
 def _headers(api_key: str | None = None) -> dict[str, str]:
@@ -179,18 +183,131 @@ def _status_rank(status: str) -> int:
     return order.get(str(status or "").strip().lower(), 9)
 
 
+def _normalized_name_candidates(value: str) -> set[str]:
+    raw = str(value or "").strip().lower()
+    if not raw:
+        return set()
+    candidates = {raw}
+    if "." in raw:
+        stem = raw.rsplit(".", 1)[0].strip().lower()
+        if stem:
+            candidates.add(stem)
+    return candidates
+
+
+def _get_account_value(account: Any, *names: str, default: str = "") -> str:
+    for name in names:
+        value = getattr(account, name, "")
+        if str(value or "").strip():
+            return str(value).strip()
+    return default
+
+
+def _load_local_chatgpt_account(account: Any) -> AccountModel | None:
+    account_id = getattr(account, "id", None)
+    email = str(getattr(account, "email", "") or "").strip()
+    user_id = str(getattr(account, "user_id", "") or "").strip()
+
+    try:
+        with Session(engine) as session:
+            if account_id is not None:
+                try:
+                    row = session.get(AccountModel, int(account_id))
+                except Exception:
+                    row = None
+                if row and str(row.platform or "").strip().lower() == "chatgpt":
+                    return row
+
+            if email:
+                row = session.exec(
+                    select(AccountModel)
+                    .where(AccountModel.platform == "chatgpt")
+                    .where(AccountModel.email == email)
+                ).first()
+                if row:
+                    return row
+
+            if user_id:
+                row = session.exec(
+                    select(AccountModel)
+                    .where(AccountModel.platform == "chatgpt")
+                    .where(AccountModel.user_id == user_id)
+                ).first()
+                if row:
+                    return row
+    except Exception:
+        return None
+    return None
+
+
+def _resolve_seed_account(account: Any) -> Any:
+    access_token = _get_account_value(account, "access_token", "token", default="")
+    email = str(getattr(account, "email", "") or "").strip()
+    if access_token and email:
+        return account
+
+    local_row = _load_local_chatgpt_account(account)
+    if not local_row:
+        return account
+
+    class _SeedAccount:
+        pass
+
+    extra = local_row.get_extra()
+    resolved = _SeedAccount()
+    resolved.id = local_row.id
+    resolved.email = local_row.email
+    resolved.user_id = local_row.user_id
+    resolved.platform = local_row.platform
+    resolved.password = local_row.password
+    resolved.token = local_row.token
+    resolved.extra = extra
+    resolved.access_token = extra.get("access_token") or local_row.token or _get_account_value(account, "access_token", "token", default="")
+    resolved.refresh_token = extra.get("refresh_token") or _get_account_value(account, "refresh_token", default="")
+    resolved.id_token = extra.get("id_token") or _get_account_value(account, "id_token", default="")
+    resolved.session_token = extra.get("session_token") or _get_account_value(account, "session_token", default="")
+    resolved.client_id = extra.get("client_id") or _get_account_value(account, "client_id", default="app_EMoamEEZ73f0CkXaXp7hrann")
+    resolved.cookies = extra.get("cookies") or _get_account_value(account, "cookies", default="")
+    return resolved
+
+
 def _match_auth_file(account: Any, files: list[dict[str, Any]]) -> dict[str, Any] | None:
     email = str(getattr(account, "email", "") or "").strip().lower()
-    if not email:
+    user_id = str(getattr(account, "user_id", "") or "").strip().lower()
+    email_local = email.split("@", 1)[0].strip().lower() if email else ""
+    if not email and not user_id:
         return None
     candidates = []
     for item in files:
         provider = str(item.get("provider") or item.get("type") or "").strip().lower()
         item_email = str(item.get("email") or "").strip().lower()
         item_name = str(item.get("name") or "").strip().lower()
+        item_user_id = str(
+            item.get("user_id")
+            or item.get("userId")
+            or item.get("chatgpt_user_id")
+            or ""
+        ).strip().lower()
+        item_auth_index = str(item.get("auth_index") or "").strip().lower()
         if provider != "codex":
             continue
-        if item_email == email or item_name == f"{email}.json":
+        name_candidates = _normalized_name_candidates(item_name)
+        if (
+            item_email == email
+            or item_email == email_local
+            or item_email == user_id
+            or item_email == f"{email_local}.json"
+            or item_name == email
+            or item_name == f"{email}.json"
+            or item_name == f"{email_local}.json"
+            or item_name == user_id
+            or item_name == f"{user_id}.json"
+            or email in name_candidates
+            or email_local in name_candidates
+            or user_id in name_candidates
+            or item_user_id == user_id
+            or (item_auth_index and item_auth_index == user_id)
+        ):
             candidates.append(item)
     if not candidates:
         return None
@@ -202,6 +319,97 @@ def _match_auth_file(account: Any, files: list[dict[str, Any]]) -> dict[str, Any
         reverse=False,
     )
     return candidates[0]
+
+
+def _seed_auth_file_from_account(account: Any, *, api_url: str | None = None, api_key: str | None = None) -> tuple[bool, str]:
+    seed_account = _resolve_seed_account(account)
+    access_token = str(
+        getattr(seed_account, "access_token", "")
+        or getattr(seed_account, "token", "")
+        or ""
+    ).strip()
+    email = str(getattr(seed_account, "email", "") or "").strip()
+    if not access_token or not email:
+        return False, "账号缺少 access_token 或 email，无法自动创建远端 auth-file"
+
+    from platforms.chatgpt.cpa_upload import generate_token_json, upload_to_cpa
+
+    return upload_to_cpa(generate_token_json(seed_account), api_url=api_url, api_key=api_key)
+
+
+def _wait_for_matching_auth_file(
+    account: Any,
+    *,
+    api_url: str | None = None,
+    api_key: str | None = None,
+    attempts: int = 5,
+    delay_seconds: float = 0.4,
+) -> dict[str, Any] | None:
+    last_files: list[dict[str, Any]] = []
+    for attempt in range(1, max(1, attempts) + 1):
+        files = _retry_sync_call(lambda: list_auth_files(api_url=api_url, api_key=api_key))
+        last_files = files
+        matched = _match_auth_file(account, files)
+        if matched:
+            return matched
+        if attempt < attempts:
+            time.sleep(delay_seconds)
+    return _match_auth_file(account, last_files)
+
+
+def _sync_remote_auth_result(
+    account: Any,
+    files: list[dict[str, Any]],
+    synced_at: str,
+    *,
+    api_url: str | None = None,
+    api_key: str | None = None,
+) -> dict[str, Any]:
+    matched = _match_auth_file(account, files)
+    if matched:
+        return _build_remote_sync_result(account, matched, synced_at, api_url=api_url, api_key=api_key)
+
+    try:
+        seeded_ok, seeded_msg = _seed_auth_file_from_account(account, api_url=api_url, api_key=api_key)
+    except Exception as exc:
+        seeded_ok, seeded_msg = False, str(exc)
+    if seeded_ok:
+        try:
+            matched = _wait_for_matching_auth_file(account, api_url=api_url, api_key=api_key)
+        except Exception as exc:
+            return {
+                "uploaded": True,
+                "last_synced_at": synced_at,
+                "message": f"{seeded_msg}；{str(exc)}",
+                "remote_state": "pending_index",
+                "base_url": _base_url(api_url),
+                "seeded": True,
+            }
+        if matched:
+            seeded_result = _build_remote_sync_result(account, matched, synced_at, api_url=api_url, api_key=api_key)
+            if not str(seeded_result.get("message") or "").strip():
+                seeded_result["message"] = seeded_msg
+            else:
+                seeded_result["message"] = f"{seeded_result['message']}；{seeded_msg}"
+            seeded_result["seeded"] = True
+            return seeded_result
+        return {
+            "uploaded": True,
+            "last_synced_at": synced_at,
+            "message": f"{seeded_msg}；已上传到 CLIProxyAPI，但远端索引尚未刷新",
+            "remote_state": "pending_index",
+            "base_url": _base_url(api_url),
+            "seeded": True,
+        }
+    if seeded_msg:
+        return {
+            "uploaded": False,
+            "last_synced_at": synced_at,
+            "message": seeded_msg,
+            "remote_state": "not_found",
+            "base_url": _base_url(api_url),
+        }
+    return _build_remote_sync_result(account, None, synced_at, api_url=api_url, api_key=api_key)
 
 
 def _probe_remote_auth(auth_index: str, account_id: str, *, api_url: str | None = None, api_key: str | None = None) -> dict[str, Any]:
@@ -347,8 +555,7 @@ def sync_chatgpt_cliproxyapi_status(
             "remote_state": "unreachable",
             "base_url": _base_url(api_url),
         }
-    matched = _match_auth_file(account, files)
-    return _build_remote_sync_result(account, matched, synced_at, api_url=api_url, api_key=api_key)
+    return _sync_remote_auth_result(account, files, synced_at, api_url=api_url, api_key=api_key)
 
 
 def sync_chatgpt_cliproxyapi_status_batch(
@@ -383,9 +590,9 @@ def sync_chatgpt_cliproxyapi_status_batch(
         account_id = getattr(account, "id", None)
         if account_id is None:
             continue
-        matched = _match_auth_file(account, files)
-        results[int(account_id)] = _build_remote_sync_result(account, matched, synced_at, api_url=api_url, api_key=api_key)
-        if index < len(accounts) - 1 and matched:
+        result = _sync_remote_auth_result(account, files, synced_at, api_url=api_url, api_key=api_key)
+        results[int(account_id)] = result
+        if index < len(accounts) - 1 and str(result.get("remote_state") or "").strip().lower() not in {"unreachable", "not_found"}:
             time.sleep(BATCH_PROBE_DELAY_SECONDS)
 
     unreachable = sum(1 for item in results.values() if str(item.get("remote_state") or "").strip().lower() == "unreachable")

--- a/services/external_apps.py
+++ b/services/external_apps.py
@@ -701,7 +701,7 @@ def _ensure_cliproxyapi_runtime_config(repo: Path):
     config_path = repo / "config.local.yaml"
     if not config_path.exists():
         shutil.copyfile(repo / "config.example.yaml", config_path)
-    secret = _get_setting("cliproxyapi_management_key", "cliproxyapi")
+    secret = _get_setting("cliproxyapi_management_key", "islam")
     lines = config_path.read_text(encoding="utf-8").splitlines()
     updated_lines = []
     replaced = False

--- a/tests/test_cliproxyapi_sync.py
+++ b/tests/test_cliproxyapi_sync.py
@@ -66,13 +66,18 @@ class CliproxyapiSyncTests(unittest.TestCase):
         self.assertEqual(sleep_mock.call_count, 2)
 
     def test_sync_returns_not_found_when_remote_auth_missing(self):
-        account = DummyAccount()
+        account = DummyAccount(token="access-token")
+        account.access_token = "access-token"
 
         with mock.patch("services.cliproxyapi_sync.list_auth_files", return_value=[]):
-            result = sync_chatgpt_cliproxyapi_status(account, api_url="http://127.0.0.1:8317", api_key="demo")
+            with mock.patch(
+                "platforms.chatgpt.cpa_upload.upload_to_cpa",
+                return_value=(False, "上传失败: HTTP 401"),
+            ):
+                result = sync_chatgpt_cliproxyapi_status(account, api_url="http://127.0.0.1:8317", api_key="demo")
 
         self.assertFalse(result["uploaded"])
-        self.assertIn("未在 CLIProxyAPI 找到匹配", result["message"])
+        self.assertIn("上传失败", result["message"])
 
     def test_sync_uses_matching_codex_auth_and_probe(self):
         account = DummyAccount(email="demo@example.com", user_id="acct-123")
@@ -104,6 +109,130 @@ class CliproxyapiSyncTests(unittest.TestCase):
         self.assertTrue(result["uploaded"])
         self.assertEqual(result["auth_index"], "auth-001")
         self.assertEqual(result["remote_state"], "usable")
+
+    def test_sync_matches_codex_auth_by_user_id_when_email_lookup_is_missing(self):
+        account = DummyAccount(email="", user_id="acct-123")
+        auth_files = [
+            {
+                "name": "acct-123.json",
+                "provider": "codex",
+                "auth_index": "auth-123",
+                "status": "active",
+                "status_message": "",
+                "unavailable": False,
+            }
+        ]
+
+        with mock.patch("services.cliproxyapi_sync.list_auth_files", return_value=auth_files):
+            with mock.patch(
+                "services.cliproxyapi_sync._probe_remote_auth",
+                return_value={
+                    "last_probe_at": "2026-03-31T00:00:00Z",
+                    "last_probe_status_code": 200,
+                    "last_probe_error_code": "",
+                    "last_probe_message": "ok",
+                    "remote_state": "usable",
+                },
+            ):
+                result = sync_chatgpt_cliproxyapi_status(account, api_url="http://127.0.0.1:8317", api_key="demo")
+
+        self.assertTrue(result["uploaded"])
+        self.assertEqual(result["auth_index"], "auth-123")
+        self.assertEqual(result["remote_state"], "usable")
+
+    def test_sync_seeds_missing_remote_auth_from_local_account(self):
+        account = DummyAccount(email="demo@example.com", token="access-token", user_id="acct-123")
+        account.access_token = "access-token"
+        account.refresh_token = "refresh-token"
+        account.id_token = ""
+        auth_files = [
+            {
+                "name": "demo@example.com.json",
+                "provider": "codex",
+                "email": "demo@example.com",
+                "auth_index": "auth-001",
+                "status": "active",
+                "status_message": "",
+                "unavailable": False,
+            }
+        ]
+
+        with mock.patch("services.cliproxyapi_sync.list_auth_files", side_effect=[[], auth_files]):
+            with mock.patch("services.cliproxyapi_sync.time.sleep"):
+                with mock.patch(
+                    "platforms.chatgpt.cpa_upload.upload_to_cpa",
+                    return_value=(True, "上传成功"),
+                ) as upload_mock:
+                    with mock.patch(
+                        "services.cliproxyapi_sync._probe_remote_auth",
+                        return_value={
+                            "last_probe_at": "2026-03-31T00:00:00Z",
+                            "last_probe_status_code": 200,
+                            "last_probe_error_code": "",
+                            "last_probe_message": "ok",
+                            "remote_state": "usable",
+                        },
+                    ):
+                        result = sync_chatgpt_cliproxyapi_status(account, api_url="http://localhost:8317", api_key="islam")
+
+        self.assertTrue(result["uploaded"])
+        self.assertEqual(result["remote_state"], "usable")
+        self.assertEqual(result["auth_index"], "auth-001")
+        self.assertTrue(result.get("seeded"))
+        upload_mock.assert_called_once()
+
+    def test_sync_seeds_missing_remote_auth_from_sqlite_row_when_account_object_lacks_token(self):
+        account = DummyAccount(email="demo@example.com", token="", user_id="acct-123")
+        account.access_token = ""
+        account.refresh_token = ""
+        account.id_token = ""
+        sqlite_row = mock.Mock()
+        sqlite_row.id = 101
+        sqlite_row.email = "demo@example.com"
+        sqlite_row.user_id = "acct-123"
+        sqlite_row.platform = "chatgpt"
+        sqlite_row.password = "pw"
+        sqlite_row.token = "sqlite-access-token"
+        sqlite_row.get_extra.return_value = {
+            "access_token": "sqlite-access-token",
+            "refresh_token": "sqlite-refresh-token",
+        }
+        auth_files = [
+            {
+                "name": "demo@example.com.json",
+                "provider": "codex",
+                "email": "demo@example.com",
+                "auth_index": "auth-101",
+                "status": "active",
+                "status_message": "",
+                "unavailable": False,
+            }
+        ]
+
+        with mock.patch("services.cliproxyapi_sync._load_local_chatgpt_account", return_value=sqlite_row):
+            with mock.patch("services.cliproxyapi_sync.list_auth_files", side_effect=[[], auth_files]):
+                with mock.patch("services.cliproxyapi_sync.time.sleep"):
+                    with mock.patch(
+                        "platforms.chatgpt.cpa_upload.upload_to_cpa",
+                        return_value=(True, "上传成功"),
+                    ) as upload_mock:
+                        with mock.patch(
+                            "services.cliproxyapi_sync._probe_remote_auth",
+                            return_value={
+                                "last_probe_at": "2026-03-31T00:00:00Z",
+                                "last_probe_status_code": 200,
+                                "last_probe_error_code": "",
+                                "last_probe_message": "ok",
+                                "remote_state": "usable",
+                            },
+                        ):
+                            result = sync_chatgpt_cliproxyapi_status(account, api_url="http://localhost:8317", api_key="islam")
+
+        self.assertTrue(result["uploaded"])
+        self.assertEqual(result["remote_state"], "usable")
+        self.assertEqual(result["auth_index"], "auth-101")
+        self.assertTrue(result.get("seeded"))
+        upload_mock.assert_called_once()
 
     def test_probe_remote_auth_maps_token_invalidated(self):
         with mock.patch(

--- a/tests/test_external_sync_contribution_mode.py
+++ b/tests/test_external_sync_contribution_mode.py
@@ -24,6 +24,56 @@ def _config_getter(values: dict[str, str]):
 
 
 class ExternalSyncContributionModeTests(unittest.TestCase):
+    def test_cpa_upload_falls_back_to_cliproxyapi_defaults_when_cpa_config_is_blank(self):
+        account = DummyAccount(
+            extra={
+                "access_token": "at-token",
+                "refresh_token": "rt-token",
+                "id_token": "id-token",
+            }
+        )
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {"message": "ok"}
+
+        cfg = {
+            "cpa_api_url": "",
+            "cpa_api_key": "",
+            "cliproxyapi_base_url": "http://localhost:8317",
+            "cliproxyapi_management_key": "islam",
+        }
+
+        with mock.patch("core.config_store.config_store.get", side_effect=_config_getter(cfg)):
+            with mock.patch("platforms.chatgpt.cpa_upload.cffi_requests.post", return_value=response) as post_mock:
+                from platforms.chatgpt.cpa_upload import generate_token_json, upload_to_cpa
+
+                ok, msg = upload_to_cpa(generate_token_json(account))
+
+        self.assertTrue(ok)
+        self.assertEqual(msg, "上传成功")
+        post_mock.assert_called_once()
+        self.assertIn("http://localhost:8317/v0/management/auth-files", post_mock.call_args.args[0])
+
+    def test_cpa_upload_synthesizes_refresh_token_when_account_is_access_token_only(self):
+        account = DummyAccount()
+        account.access_token = "at-token"
+        account.session_token = "session-token"
+        account.id_token = "id-token"
+        response = mock.Mock()
+        response.status_code = 200
+        response.json.return_value = {"message": "ok"}
+
+        with mock.patch("core.config_store.config_store.get", return_value=""):
+            with mock.patch("platforms.chatgpt.cpa_upload.cffi_requests.post", return_value=response) as post_mock:
+                from platforms.chatgpt.cpa_upload import generate_token_json, upload_to_cpa
+
+                payload = generate_token_json(account)
+                ok, msg = upload_to_cpa(payload)
+
+        self.assertTrue(ok)
+        self.assertEqual(msg, "上传成功")
+        self.assertEqual(payload["refresh_token"], "session-token")
+
     def test_contribution_enabled_uploads_only_to_contribution_server(self):
         account = DummyAccount()
         cfg = {


### PR DESCRIPTION
English
This PR fixes the CPA/CLIProxy import-export path:
- uses local SQLite-backed defaults for CLIProxyAPI
- falls back to the local account row when remote auth-file lookup fails
- synthesizes a usable refresh token for access-token-only exports

中文
这个 PR 修复 CPA / CLIProxy 的导入导出链路：
- 使用本地 SQLite 配置作为 CLIProxyAPI 默认值
- 远端 auth-file 找不到时回退本地账号记录
- 对只有 access token 的导出补全可用的 refresh token