### PR TITLE
feat: add ARM architecture support for Docker build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -55,7 +55,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ FROM python:3.12-slim AS runtime
 
 ARG CAMOUFOX_VERSION=135.0.1
 ARG CAMOUFOX_RELEASE=beta.24
+ARG TARGETARCH
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -38,7 +39,12 @@ COPY scripts/install_camoufox.py /tmp/install_camoufox.py
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl ca-certificates \
         libgtk-3-0 libx11-xcb1 libasound2 xvfb xauth \
-    && curl -fsSL https://go.dev/dl/go1.24.2.linux-amd64.tar.gz | tar -C /usr/local -xz \
+    && GOARCH=${TARGETARCH:-amd64} \
+    && if [ "$GOARCH" = "amd64" ]; then GOARCH="amd64"; \
+       elif [ "$GOARCH" = "arm64" ]; then GOARCH="arm64"; \
+       elif [ "$GOARCH" = "arm" ]; then GOARCH="armv6l"; \
+       else GOARCH="amd64"; fi \
+    && curl -fsSL https://go.dev/dl/go1.24.2.linux-${GOARCH}.tar.gz | tar -C /usr/local -xz \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## 问题
当前 Dockerfile 硬编码了 amd64 架构的 Go 安装包，导致无法在 ARM 系统上构建。

## 修改内容
- 添加 `TARGETARCH` 参数支持多架构构建
- 动态检测并安装对应架构的 Go 二进制文件（amd64/arm64/armv6l）
- 支持构建时自动识别系统架构

## 支持的架构
- ✅ AMD64 (x86_64)
- ✅ ARM64 (aarch64) - Apple Silicon, AWS Graviton, 树莓派 4/5
- ✅ ARM (armv6l) - 树莓派 Zero/1

## 测试
```bash
docker compose up -d --build
```

## 技术细节
修改了 Dockerfile 第 18 行和第 42-47 行：
- 添加 `ARG TARGETARCH` 接收 Docker 自动传入的目标架构
- 使用条件判断动态选择 Go 安装包 URL
- 默认回退到 amd64 以保持向后兼容

docker-compose.yml 无需修改，Docker 会自动根据运行系统架构设置 TARGETARCH。