### PR TITLE
修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,11 +557,11 @@ Electron 开发模式不会自动启动 Python 后端。
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=zc-zhangchen%2Fany-auto-register&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#zc-zhangchen/any-auto-register&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=zc-zhangchen/any-auto-register&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/image?repos=zc-zhangchen/any-auto-register&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README_en.md
+++ b/README_en.md
@@ -547,11 +547,11 @@ If this project has been helpful to you, please support the author to continue m
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=zc-zhangchen%2Fany-auto-register&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#zc-zhangchen/any-auto-register&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=zc-zhangchen/any-auto-register&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/image?repos=zc-zhangchen/any-auto-register&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README_vi.md
+++ b/README_vi.md
@@ -547,11 +547,11 @@ Nếu dự án này hữu ích với bạn, vui lòng ủng hộ để tác gi�
 
 ## Lịch sử Star
 
-<a href="https://www.star-history.com/?repos=zc-zhangchen%2Fany-auto-register&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#zc-zhangchen/any-auto-register&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=zc-zhangchen/any-auto-register&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/image?repos=zc-zhangchen/any-auto-register&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/image?repos=zc-zhangchen/any-auto-register&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
当前 Star History 图表已无法正常显示。本 PR 更新中文、英文和越南文 README 中的图表链接，确保项目星标历史可以正常展示。