### PR TITLE
修复凭据密钥随容器重建丢失及 iCloud 502 日志

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     APP_CONDA_ENV=docker \
     APP_RELOAD=0 \
     APP_RUNTIME_DIR=/runtime \
+    CREDENTIAL_ENCRYPTION_KEY_FILE=/runtime/.secrets/credential_key \
     APP_ENABLE_SOLVER=1 \
     SOLVER_PORT=8889 \
     SOLVER_BIND_HOST=0.0.0.0 \

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -33,6 +33,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PORT=8000 \
     APP_RELOAD=0 \
     APP_RUNTIME_DIR=/runtime \
+    CREDENTIAL_ENCRYPTION_KEY_FILE=/runtime/.secrets/credential_key \
     APP_ENABLE_SOLVER=0
 
 WORKDIR /app

--- a/api/icloud.py
+++ b/api/icloud.py
@@ -34,6 +34,7 @@ _ERROR_STATUS = {
     "invalid_verification_code": 400,
     "invalid_credentials": 401,
     "session_expired": 401,
+    "credentials_unreadable": 409,
     "mail_access_denied": 403,
     "provider_rate_limited": 429,
     "upstream_rejected": 502,

--- a/api/icloud.py
+++ b/api/icloud.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Optional
 
 from fastapi import APIRouter, HTTPException
@@ -17,6 +18,8 @@ from platforms.icloud import (
     SessionImportRequest,
 )
 from services import icloud_service
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/icloud", tags=["icloud"])
 
@@ -41,7 +44,12 @@ _ERROR_STATUS = {
 
 
 def _http_error(error: ICloudError) -> HTTPException:
-    return HTTPException(_ERROR_STATUS.get(error.code, 502), str(error))
+    status = _ERROR_STATUS.get(error.code, 502)
+    # 上游失败的原因只存在于响应体里，而反向代理（Cloudflare 等）会把 5xx 的响应体
+    # 换成自己的错误页，运维侧就彻底看不到 Apple 到底回了什么。所以这里落一条日志。
+    if status >= 500:
+        logger.error("iCloud 上游失败 [%s] -> HTTP %s: %s", error.code, status, error)
+    return HTTPException(status, str(error))
 
 
 class LoginStartRequest(BaseModel):

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -21,6 +21,8 @@ services:
       APP_RUNTIME_DIR: /runtime
       APP_ENABLE_SOLVER: "0"
       DATABASE_URL: sqlite:////runtime/account_manager.db
+      # 必须落在挂载卷里，否则每次重建容器都会换密钥，库里的凭据全部作废
+      CREDENTIAL_ENCRYPTION_KEY_FILE: /runtime/.secrets/credential_key
     ports:
       - "${APP_PORT_BIND:-127.0.0.1:8000}:8000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       APP_RELOAD: "0"
       APP_CONDA_ENV: docker
       APP_RUNTIME_DIR: /runtime
+      # 必须落在挂载卷里，否则每次重建容器都会换密钥，库里的凭据全部作废
+      CREDENTIAL_ENCRYPTION_KEY_FILE: /runtime/.secrets/credential_key
       APP_ENABLE_SOLVER: "1"
       SOLVER_PORT: "8889"
       SOLVER_BIND_HOST: 0.0.0.0

--- a/docker/entrypoint.server.sh
+++ b/docker/entrypoint.server.sh
@@ -10,6 +10,12 @@ RUNTIME_DIR="${APP_RUNTIME_DIR:-/runtime}"
 mkdir -p "${RUNTIME_DIR}" "${RUNTIME_DIR}/logs"
 touch "${RUNTIME_DIR}/account_manager.db"
 
+# 凭据加密密钥必须和数据库一起留在挂载卷里。放在镜像内的默认位置（/app/.secrets）
+# 会在每次重建容器时重新生成，导致库里已加密的 iCloud/ChatGPT 凭据全部解不开
+# （decrypt 抛 InvalidTag），而且没有任何补救手段。
+mkdir -p "$(dirname "${CREDENTIAL_ENCRYPTION_KEY_FILE:-${RUNTIME_DIR}/.secrets/credential_key}")"
+chmod 700 "$(dirname "${CREDENTIAL_ENCRYPTION_KEY_FILE:-${RUNTIME_DIR}/.secrets/credential_key}")"
+
 ln -sfn "${RUNTIME_DIR}/account_manager.db" "${APP_DIR}/account_manager.db"
 
 if ! command -v node >/dev/null 2>&1; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,5 +12,11 @@ touch \
 ln -sfn "${RUNTIME_DIR}/account_manager.db" "${APP_DIR}/account_manager.db"
 ln -sfn "${RUNTIME_DIR}/logs/solver.log" "${APP_DIR}/services/turnstile_solver/solver.log"
 
+# 凭据加密密钥必须和数据库一起留在挂载卷里。放在镜像内的默认位置（/app/.secrets）
+# 会在每次重建容器时重新生成，导致库里已加密的 iCloud/ChatGPT 凭据全部解不开
+# （decrypt 抛 InvalidTag），而且没有任何补救手段。
+mkdir -p "$(dirname "${CREDENTIAL_ENCRYPTION_KEY_FILE:-${RUNTIME_DIR}/.secrets/credential_key}")"
+chmod 700 "$(dirname "${CREDENTIAL_ENCRYPTION_KEY_FILE:-${RUNTIME_DIR}/.secrets/credential_key}")"
+
 echo "[entrypoint] Starting backend under Xvfb so Docker can handle both headed and headless browser tasks"
 exec xvfb-run -a --server-args="-screen 0 1920x1080x24" python main.py

--- a/platforms/icloud/errors.py
+++ b/platforms/icloud/errors.py
@@ -23,9 +23,11 @@ class ICloudError(RuntimeError):
         self.__cause__ = cause
 
     def __str__(self) -> str:
-        if self.__cause__ is None:
+        # 有些异常（如 cryptography 的 InvalidTag）str() 为空，直接拼会留下一个"（）"。
+        cause = str(self.__cause__) if self.__cause__ is not None else ""
+        if not cause.strip():
             return self.message
-        return f"{self.message}（{self.__cause__}）"
+        return f"{self.message}（{cause}）"
 
 
 def invalid_config(message: str, cause: Optional[BaseException] = None) -> ICloudError:

--- a/services/icloud_service.py
+++ b/services/icloud_service.py
@@ -56,7 +56,17 @@ def _account_lock(account_id: int) -> threading.Lock:
 
 
 def load_credentials(row: ICloudAccountModel) -> ICloudCredentials:
-    return ICloudCredentials.from_dict(secret_box.decrypt_json(row.credentials_cipher))
+    try:
+        payload = secret_box.decrypt_json(row.credentials_cipher)
+    except Exception as exc:
+        # 密文本身没坏，是解密密钥换了（最常见的原因是密钥没放在挂载卷里，
+        # 重建容器时被重新生成）。抛原始的 InvalidTag 只会得到一个 500，
+        # 用户看不出该怎么办——只能重新登录主号。
+        raise ICloudError(
+            "credentials_unreadable",
+            f"iCloud 主号 {row.email} 的凭据无法解密（加密密钥已变更），请重新登录该主号",
+        ) from exc
+    return ICloudCredentials.from_dict(payload)
 
 
 def get_account(account_id: int) -> ICloudAccountModel:

--- a/tests/test_docker_credential_key_persistence.py
+++ b/tests/test_docker_credential_key_persistence.py
@@ -1,0 +1,77 @@
+"""守住"凭据密钥必须放在挂载卷里"这条部署约束。
+
+core.secret_box 的默认密钥路径是 ``Path.cwd()/.secrets/credential_key``，在容器里
+就是 /app/.secrets/credential_key —— 那是镜像层，不是挂载卷。一旦用默认值，
+``docker compose up --build`` 重建容器就会生成一把新密钥，而数据库还在卷里躺着，
+里面所有 credentials_cipher 都变成解不开的密文（decrypt 抛 InvalidTag），
+且无法恢复，用户只能重新登录所有账号。
+
+所以两个镜像和两份 compose 都必须显式把密钥指到 /runtime 下面。
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+from cryptography.exceptions import InvalidTag
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUNTIME_MOUNT = "/runtime"
+ENV_VAR = "CREDENTIAL_ENCRYPTION_KEY_FILE"
+
+DOCKERFILES = ["Dockerfile", "Dockerfile.server"]
+COMPOSE_FILES = ["docker-compose.yml", "docker-compose.server.yml"]
+ENTRYPOINTS = ["docker/entrypoint.sh", "docker/entrypoint.server.sh"]
+
+
+@pytest.mark.parametrize("name", DOCKERFILES)
+def test_dockerfile_pins_key_onto_runtime_volume(name):
+    text = (REPO_ROOT / name).read_text(encoding="utf-8")
+    match = re.search(rf"{ENV_VAR}=(\S+)", text)
+    assert match, f"{name} 没有设置 {ENV_VAR}，重建容器会换掉凭据密钥"
+    assert match.group(1).startswith(RUNTIME_MOUNT + "/"), (
+        f"{name} 的 {ENV_VAR}={match.group(1)} 不在 {RUNTIME_MOUNT} 挂载卷里"
+    )
+
+
+@pytest.mark.parametrize("name", COMPOSE_FILES)
+def test_compose_pins_key_onto_runtime_volume(name):
+    config = yaml.safe_load((REPO_ROOT / name).read_text(encoding="utf-8"))
+    environment = config["services"]["app"]["environment"]
+    assert ENV_VAR in environment, f"{name} 没有设置 {ENV_VAR}"
+    assert str(environment[ENV_VAR]).startswith(RUNTIME_MOUNT + "/")
+
+
+@pytest.mark.parametrize("name", COMPOSE_FILES)
+def test_compose_mounts_the_runtime_volume(name):
+    """密钥指向 /runtime 只有在 /runtime 真的是挂载卷时才有意义。"""
+    config = yaml.safe_load((REPO_ROOT / name).read_text(encoding="utf-8"))
+    volumes = config["services"]["app"]["volumes"]
+    # 宿主机一侧可能写成 ${APP_RUNTIME_BIND:-./data}，冒号不能当成字段分隔符用，
+    # 所以这里只检查 /runtime 作为某一段出现过。
+    assert any(RUNTIME_MOUNT in str(v).split(":") for v in volumes), (
+        f"{name} 没有把 {RUNTIME_MOUNT} 挂出来，密钥仍然会随容器销毁"
+    )
+
+
+@pytest.mark.parametrize("name", ENTRYPOINTS)
+def test_entrypoint_prepares_key_directory(name):
+    text = (REPO_ROOT / name).read_text(encoding="utf-8")
+    assert ENV_VAR in text, f"{name} 没有准备密钥目录"
+
+
+def test_rotating_the_key_makes_stored_credentials_unreadable(monkeypatch):
+    """说明后果：换了密钥，旧密文就再也解不开。"""
+    from core.secret_box import SecretBox
+
+    monkeypatch.setenv("CREDENTIAL_ENCRYPTION_KEY", base64.b64encode(os.urandom(32)).decode())
+    sealed = SecretBox().encrypt_json({"session": "icloud-cookie"})
+
+    monkeypatch.setenv("CREDENTIAL_ENCRYPTION_KEY", base64.b64encode(os.urandom(32)).decode())
+    with pytest.raises(InvalidTag):
+        SecretBox().decrypt_json(sealed)

--- a/tests/test_icloud_service.py
+++ b/tests/test_icloud_service.py
@@ -110,6 +110,27 @@ def test_reimport_keeps_existing_imap_password_when_not_resubmitted(service, stu
     assert credentials.imap_password == "app-specific"
 
 
+def test_unreadable_credentials_report_a_relogin_hint(service, stub_web_client, monkeypatch):
+    """密钥换掉后旧密文解不开，要给出"重新登录"而不是裸的 InvalidTag。"""
+    stub_web_client["client"] = _StubWebClient(imported=_imported())
+    account = service.import_session(SessionImportRequest(cookie_header="a=1"))
+
+    import core.secret_box as secret_box_module
+
+    monkeypatch.setenv("CREDENTIAL_ENCRYPTION_KEY", base64.b64encode(os.urandom(32)).decode())
+    monkeypatch.setattr(service, "secret_box", secret_box_module.SecretBox())
+
+    row = service.get_account(account["id"])
+    with pytest.raises(ICloudError) as excinfo:
+        service.load_credentials(row)
+
+    assert excinfo.value.code == "credentials_unreadable"
+    assert "重新登录" in str(excinfo.value)
+
+    # 账号列表不能因此整个 500，要能标出这一条坏掉了
+    assert service.list_accounts()[0]["credential_state"] == {"credentials_unreadable": True}
+
+
 def test_generate_alias_enforces_hourly_quota(service, stub_web_client):
     stub_web_client["client"] = _StubWebClient(imported=_imported())
     account = service.import_session(SessionImportRequest(cookie_header="a=1"))

--- a/tests/test_icloud_service.py
+++ b/tests/test_icloud_service.py
@@ -126,6 +126,8 @@ def test_unreadable_credentials_report_a_relogin_hint(service, stub_web_client, 
 
     assert excinfo.value.code == "credentials_unreadable"
     assert "重新登录" in str(excinfo.value)
+    # InvalidTag 的 str() 是空的，不能在消息尾巴上留一个空括号
+    assert not str(excinfo.value).endswith("（）")
 
     # 账号列表不能因此整个 500，要能标出这一条坏掉了
     assert service.list_accounts()[0]["credential_state"] == {"credentials_unreadable": True}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
修复部署相关问题：

- iCloud 上游失败时把原因写到服务端日志（Cloudflare 会替换 5xx 响应体，前端只能看到 502）
- 凭据加密密钥落到挂载卷，避免重建容器后已保存凭据全部作废
- `ICloudError` 在 cause 无消息时不再拼出空括号

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35260470-e43e-4abe-a670-08823bc564b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35260470-e43e-4abe-a670-08823bc564b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

