### PR TITLE
iCloud 上游拒绝改为 422，避免 Cloudflare 吞掉错误原因

### DIFF
--- a/api/icloud.py
+++ b/api/icloud.py
@@ -33,7 +33,10 @@ _ERROR_STATUS = {
     "session_expired": 401,
     "mail_access_denied": 403,
     "provider_rate_limited": 429,
-    "upstream_rejected": 502,
+    # upstream_rejected 是"Apple 收到了并明确拒绝"，属于请求语义问题而不是网关故障。
+    # 用 5xx 表达还有个致命副作用：Cloudflare 会把 5xx 的响应体整个换成自己的错误页，
+    # 用户只看得到一张 "502 Bad gateway"，Apple 到底说了什么全丢了。
+    "upstream_rejected": 422,
     "upstream_error": 502,
     "invalid_response": 502,
     "upstream_unavailable": 503,

--- a/tests/test_icloud_api.py
+++ b/tests/test_icloud_api.py
@@ -163,6 +163,25 @@ def test_upstream_failure_maps_to_http_503(client, monkeypatch):
     assert icloud_service.get_account(account["id"]).sync_error == "Apple 服务暂时不可用"
 
 
+def test_apple_rejection_stays_in_4xx_so_the_reason_survives(client, monkeypatch):
+    """Apple 明确拒绝要走 4xx。
+
+    用 5xx 表达的话，Cloudflare 会把响应体换成自己的 "502 Bad gateway" 页面，
+    Apple 给的原因就彻底没了——线上就是这么丢的。
+    """
+    account = _import_account(client)
+
+    def _rejected(*_args, **_kwargs):
+        raise ICloudError("upstream_rejected", "iCloud HME 拒绝了请求")
+
+    monkeypatch.setattr(client.stub, "generate_private_email", _rejected)
+
+    response = client.post("/api/icloud/aliases", json={"account_id": account["id"]})
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "iCloud HME 拒绝了请求"
+
+
 def test_unknown_account_and_alias_map_to_http_404(client):
     assert client.post("/api/icloud/accounts/999/sync").status_code == 404
     assert client.request("DELETE", "/api/icloud/aliases/999").status_code == 404


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
把 iCloud `upstream_rejected` 从 502 改为 422，与 auto-icloud-mail 一致。

Apple 明确拒绝不是网关故障。用 5xx 时 Cloudflare 会替换响应体，前端只能看到 Bad gateway，真实原因丢失。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35260470-e43e-4abe-a670-08823bc564b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35260470-e43e-4abe-a670-08823bc564b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

