### PR TITLE
前端配色整体调柔和

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,7 @@ import Settings from '@/pages/Settings'
 import TaskHistory from '@/pages/TaskHistory'
 import RunningTasks from '@/pages/RunningTasks'
 import Login from '@/pages/Login'
-import { darkTheme, lightTheme } from './theme'
+import { applyThemeVars, darkTheme, lightTheme } from './theme'
 import { apiFetch, clearToken, getToken } from '@/lib/utils'
 
 const { Sider, Content } = Layout
@@ -67,11 +67,7 @@ function AppContent() {
   const navigate = useNavigate()
 
   useEffect(() => {
-    document.documentElement.classList.toggle('light', themeMode === 'light')
-    document.documentElement.style.setProperty(
-      '--sider-trigger-border',
-      themeMode === 'light' ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.15)'
-    )
+    applyThemeVars(themeMode)
     localStorage.setItem('theme', themeMode)
   }, [themeMode])
 
@@ -147,8 +143,8 @@ function AppContent() {
           collapsed={collapsed}
           onCollapse={setCollapsed}
           style={{
-            background: currentTheme.token?.colorBgContainer,
-            borderRight: `1px solid ${currentTheme.token?.colorBorder}`,
+            background: 'var(--bg-container)',
+            borderRight: '1px solid var(--border)',
           }}
           width={220}
         >
@@ -158,17 +154,17 @@ function AppContent() {
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              borderBottom: `1px solid ${currentTheme.token?.colorBorder}`,
+              borderBottom: '1px solid var(--border)',
             }}
           >
-            <DashboardOutlined style={{ fontSize: 20, color: currentTheme.token?.colorPrimary }} />
+            <DashboardOutlined style={{ fontSize: 20, color: 'var(--accent)' }} />
             {!collapsed && (
               <span
                 style={{
                   marginLeft: 8,
                   fontWeight: 600,
                   fontSize: 14,
-                  color: currentTheme.token?.colorText,
+                  color: 'var(--text)',
                 }}
               >
                 Account Manager
@@ -231,7 +227,7 @@ function AppContent() {
           style={{
             padding: 24,
             overflow: 'auto',
-            background: currentTheme.token?.colorBgLayout,
+            background: 'var(--bg-layout)',
           }}
         >
           <Routes>

--- a/frontend/src/components/TaskLogPanel.tsx
+++ b/frontend/src/components/TaskLogPanel.tsx
@@ -39,6 +39,13 @@ function normalizeSummary(next: RegisterSummary): RegisterSummary {
   return { success, registered, total }
 }
 
+function lineToneClass(line: string): string {
+  if (line.includes('✓') || line.includes('成功')) return 'log-line--success'
+  if (line.includes('✗') || line.includes('失败') || line.includes('错误')) return 'log-line--danger'
+  if (line.includes('停止') || line.includes('跳过')) return 'log-line--warning'
+  return ''
+}
+
 function mergeSummary(previous: RegisterSummary, incoming: Partial<RegisterSummary>): RegisterSummary {
   return normalizeSummary({
     success: incoming.success ?? previous.success,
@@ -274,19 +281,19 @@ export function TaskLogPanel({ taskId, onDone, kind = 'register' }: TaskLogPanel
 
   const footerText =
     terminalStatus === 'done'
-      ? { text: text.done, color: '#10b981' }
+      ? { text: text.done, color: 'var(--success)' }
       : terminalStatus === 'stopped'
-        ? { text: '任务已停止', color: '#d97706' }
+        ? { text: '任务已停止', color: 'var(--warning)' }
         : terminalStatus === 'failed'
-          ? { text: '任务失败', color: '#dc2626' }
+          ? { text: '任务失败', color: 'var(--danger)' }
           : null
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
       <Space wrap style={{ marginBottom: 8 }}>
-        <Tag color="green">{text.success}：{summary.success}</Tag>
-        <Tag color="blue">{text.registered}：{summary.registered}</Tag>
-        <Tag color="default">{text.total}：{summary.total}</Tag>
+        <Tag className="log-stat log-stat--success" bordered={false}>{text.success}：{summary.success}</Tag>
+        <Tag className="log-stat log-stat--info" bordered={false}>{text.registered}：{summary.registered}</Tag>
+        <Tag className="log-stat" bordered={false}>{text.total}：{summary.total}</Tag>
       </Space>
 
       <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
@@ -323,11 +330,9 @@ export function TaskLogPanel({ taskId, onDone, kind = 'register' }: TaskLogPanel
           flex: 1,
           overflowY: 'auto',
           overflowX: 'hidden',
-          background: '#ffffff',
-          border: '1px solid #e5e7eb',
-          borderRadius: 8,
-          padding: 12,
-          fontFamily: 'monospace',
+          borderRadius: 10,
+          padding: '12px 14px',
+          fontFamily: '"SFMono-Regular", Menlo, Consolas, monospace',
           fontSize: 12,
           minHeight: 320,
           maxHeight: '65vh',
@@ -338,23 +343,10 @@ export function TaskLogPanel({ taskId, onDone, kind = 'register' }: TaskLogPanel
           wordBreak: 'break-word',
         }}
       >
-        {lines.length === 0 && !error && <div style={{ color: '#9ca3af' }}>等待日志...</div>}
-        {error && <div style={{ color: '#dc2626' }}>{error}</div>}
+        {lines.length === 0 && !error && <div className="log-placeholder">等待日志...</div>}
+        {error && <div className="log-error">{error}</div>}
         {lines.map((line, index) => (
-          <div
-            key={index}
-            style={{
-              lineHeight: 1.5,
-              color:
-                line.includes('✓') || line.includes('成功')
-                  ? '#059669'
-                  : line.includes('✗') || line.includes('失败') || line.includes('错误')
-                    ? '#dc2626'
-                    : line.includes('停止') || line.includes('跳过')
-                      ? '#d97706'
-                      : '#1f2937',
-            }}
-          >
+          <div key={index} className={`log-line ${lineToneClass(line)}`}>
             {line}
           </div>
         ))}

--- a/frontend/src/components/settings/MailImportPanel.tsx
+++ b/frontend/src/components/settings/MailImportPanel.tsx
@@ -642,7 +642,7 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
         {supportsAliasSplit ? (
           <div
             style={{
-              border: '1px dashed rgba(127,127,127,0.35)',
+              border: '1px dashed var(--border-strong)',
               borderRadius: 8,
               padding: 12,
               display: 'flex',
@@ -753,10 +753,10 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
         ) : (
           <div
             style={{
-              border: '1px solid rgba(127,127,127,0.25)',
+              border: '1px solid var(--border)',
               borderRadius: 8,
               padding: 12,
-              background: 'rgba(127,127,127,0.06)',
+              background: 'var(--bg-subtle)',
               minHeight: 88,
               display: 'flex',
               alignItems: 'center',

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,34 @@
+/* 变量在 theme.ts 里按主题注入，这里放一份暗色默认值兜首屏 */
+:root {
+  --bg-layout: #161922;
+  --bg-container: #1e212c;
+  --bg-elevated: #262a36;
+  --bg-subtle: rgba(255, 255, 255, 0.045);
+  --border: rgba(255, 255, 255, 0.09);
+  --border-strong: rgba(255, 255, 255, 0.14);
+  --text: #d7dce5;
+  --text-secondary: #a4adbd;
+  --text-muted: #7b8595;
+  --accent: #5f82b8;
+  --accent-hover: #7396c8;
+  --accent-soft: rgba(95, 130, 184, 0.16);
+  --success: #6cbf9a;
+  --success-soft: rgba(108, 191, 154, 0.14);
+  --warning: #d3a26b;
+  --warning-soft: rgba(211, 162, 107, 0.14);
+  --danger: #cf8181;
+  --danger-soft: rgba(207, 129, 129, 0.14);
+  --log-bg: #191c24;
+  --log-border: rgba(255, 255, 255, 0.07);
+  --log-text: #c3cad6;
+  --log-muted: #79828f;
+  --log-success: #7fc2a1;
+  --log-warning: #d7a86e;
+  --log-danger: #d48c8c;
+  --selection-bg: rgba(95, 130, 184, 0.38);
+  color-scheme: dark;
+}
+
 * {
   margin: 0;
   padding: 0;
@@ -8,6 +39,8 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: var(--bg-layout);
+  color: var(--text);
 }
 
 #root {
@@ -16,24 +49,6 @@ body {
 
 .ant-layout-sider-trigger {
   border-top: 1px solid var(--sider-trigger-border, rgba(255, 255, 255, 0.15));
-}
-
-::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
-}
-
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  background: rgba(128, 128, 128, 0.3);
-  border-radius: 3px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: rgba(128, 128, 128, 0.5);
 }
 
 /* ── 全局动画 ────────────────────────────── */
@@ -86,7 +101,7 @@ body {
 
 .hover-lift:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.22);
 }
 
 /* ── 滚动条样式 ──────────────────────────── */
@@ -96,11 +111,11 @@ body {
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--bg-base);
+  background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border);
+  background: var(--border-strong);
   border-radius: 4px;
 }
 
@@ -110,12 +125,62 @@ body {
 
 /* ── 选择颜色 ────────────────────────────── */
 ::selection {
-  background: rgba(99, 102, 241, 0.6);
-  color: white;
+  background: var(--selection-bg);
+  color: inherit;
 }
 
-.log-panel::selection,
-.log-panel *::selection {
-  background: rgba(99, 102, 241, 0.35);
-  color: inherit;
+/* ── 弹窗：遮罩和投影都收一点，避免硬切 ────── */
+.ant-modal-mask {
+  background: rgba(12, 14, 20, 0.55);
+}
+
+.light .ant-modal-mask {
+  background: rgba(15, 23, 42, 0.3);
+}
+
+.ant-modal-content,
+.ant-drawer-content {
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.32);
+}
+
+.ant-modal-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 12px;
+  margin-bottom: 16px;
+}
+
+/* ── 任务日志面板（注册 / 补 RT 共用）───────── */
+.log-panel {
+  background: var(--log-bg);
+  border: 1px solid var(--log-border);
+  color: var(--log-text);
+}
+
+.log-panel .log-line {
+  line-height: 1.6;
+  color: var(--log-text);
+}
+
+.log-panel .log-line--success { color: var(--log-success); }
+.log-panel .log-line--danger { color: var(--log-danger); }
+.log-panel .log-line--warning { color: var(--log-warning); }
+.log-panel .log-placeholder { color: var(--log-muted); }
+.log-panel .log-error { color: var(--log-danger); }
+
+.log-stat {
+  border: 1px solid transparent;
+  background: var(--bg-subtle);
+  color: var(--text-secondary);
+}
+
+.log-stat--success {
+  background: var(--success-soft);
+  border-color: var(--success-soft);
+  color: var(--success);
+}
+
+.log-stat--info {
+  background: var(--accent-soft);
+  border-color: var(--accent-soft);
+  color: var(--accent-hover);
 }

--- a/frontend/src/lib/platforms.ts
+++ b/frontend/src/lib/platforms.ts
@@ -23,7 +23,7 @@ export const PLATFORMS: Record<PlatformName, PlatformMeta> = {
   chatgpt: {
     name: 'chatgpt',
     label: 'ChatGPT',
-    color: '#3b82f6',
+    color: '#6d90c7',
     executors: ['protocol', 'headless', 'headed'],
     usesMailbox: true,
     usesCaptcha: true,
@@ -31,7 +31,7 @@ export const PLATFORMS: Record<PlatformName, PlatformMeta> = {
   icloud: {
     name: 'icloud',
     label: 'iCloud 隐私邮箱',
-    color: '#0ea5e9',
+    color: '#5b8db3',
     executors: ['protocol'],
     usesMailbox: false,
     usesCaptcha: false,
@@ -54,7 +54,7 @@ export function getPlatformLabel(platform?: string): string {
 }
 
 export function getPlatformColor(platform?: string): string {
-  return getPlatformMeta(platform)?.color ?? '#6366f1'
+  return getPlatformMeta(platform)?.color ?? '#7b8595'
 }
 
 export function getSupportedExecutors(platform?: string): ExecutorType[] {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,10 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { applyThemeVars } from './theme'
+
+// 登录页不在 AppContent 里，变量得在挂载前就落到 <html> 上
+applyThemeVars((localStorage.getItem('theme') as 'dark' | 'light') || 'dark')
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -876,7 +876,7 @@ export default function Accounts() {
             overflow: 'auto',
             padding: 12,
             borderRadius: 8,
-            background: 'rgba(127,127,127,0.08)',
+            background: 'var(--bg-subtle)',
             fontSize: 12,
             lineHeight: 1.5,
             whiteSpace: 'pre-wrap',
@@ -907,7 +907,7 @@ export default function Accounts() {
             overflow: 'auto',
             padding: 12,
             borderRadius: 8,
-            background: 'rgba(127,127,127,0.08)',
+            background: 'var(--bg-subtle)',
             fontSize: 12,
             lineHeight: 1.5,
             whiteSpace: 'pre-wrap',
@@ -1216,7 +1216,7 @@ export default function Accounts() {
       width: 120,
       render: (_: any, record: any) => {
         const rt = getRefreshToken(record)
-        if (!rt) return <span style={{ color: '#ccc' }}>-</span>
+        if (!rt) return <span style={{ color: 'var(--text-muted)' }}>-</span>
         return (
           <Space size={6} style={{ width: '100%', justifyContent: 'space-between' }}>
             <Text style={{ ...secretPreviewStyle, fontSize: 11, maxWidth: 58 }} title={rt}>
@@ -1688,8 +1688,8 @@ export default function Accounts() {
         confirmLoading={importLoading}
         maskClosable={false}
       >
-        <p style={{ marginBottom: 8, fontSize: 12, color: '#7a8ba3' }}>
-          每行格式: <code style={{ background: 'rgba(255,255,255,0.1)', padding: '2px 4px', borderRadius: 4 }}>email password [cashier_url]</code>
+        <p style={{ marginBottom: 8, fontSize: 12, color: 'var(--text-muted)' }}>
+          每行格式: <code style={{ background: 'var(--bg-subtle)', padding: '2px 4px', borderRadius: 4 }}>email password [cashier_url]</code>
         </p>
         <Input.TextArea
           value={importText}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -41,25 +41,25 @@ export default function Dashboard() {
       title: '总账号数',
       value: stats?.total ?? 0,
       icon: <UserOutlined style={{ fontSize: 32 }} />,
-      color: '#6366f1',
+      color: 'var(--accent)',
     },
     {
       title: '试用中',
       value: stats?.by_status?.trial ?? 0,
       icon: <ClockCircleOutlined style={{ fontSize: 32 }} />,
-      color: '#f59e0b',
+      color: 'var(--warning)',
     },
     {
       title: '已订阅',
       value: stats?.by_status?.subscribed ?? 0,
       icon: <CheckCircleOutlined style={{ fontSize: 32 }} />,
-      color: '#10b981',
+      color: 'var(--success)',
     },
     {
       title: '已失效',
       value: (stats?.by_status?.expired ?? 0) + (stats?.by_status?.invalid ?? 0),
       icon: <CloseCircleOutlined style={{ fontSize: 32 }} />,
-      color: '#ef4444',
+      color: 'var(--danger)',
     },
   ]
 
@@ -68,7 +68,7 @@ export default function Dashboard() {
       <div style={{ marginBottom: 24, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div>
           <h1 style={{ fontSize: 24, fontWeight: 'bold', margin: 0 }}>仪表盘</h1>
-          <p style={{ color: '#7a8ba3', marginTop: 4 }}>账号总览</p>
+          <p style={{ color: 'var(--text-muted)', marginTop: 4 }}>账号总览</p>
         </div>
         <Button icon={<ReloadOutlined spin={loading} />} onClick={load} loading={loading}>
           刷新
@@ -110,7 +110,7 @@ export default function Dashboard() {
                 </div>
               ))
             ) : (
-              <div style={{ textAlign: 'center', color: '#7a8ba3' }}>加载中...</div>
+              <div style={{ textAlign: 'center', color: 'var(--text-muted)' }}>加载中...</div>
             )}
           </Card>
         </Col>
@@ -130,7 +130,7 @@ export default function Dashboard() {
                     justifyContent: 'space-between',
                     alignItems: 'center',
                     padding: '8px 0',
-                    borderBottom: '1px solid rgba(255,255,255,0.1)',
+                    borderBottom: '1px solid var(--border)',
                   }}
                 >
                   <Tag color={STATUS_COLORS[status] || 'default'}>{status}</Tag>
@@ -138,7 +138,7 @@ export default function Dashboard() {
                 </div>
               ))
             ) : (
-              <div style={{ textAlign: 'center', color: '#7a8ba3' }}>加载中...</div>
+              <div style={{ textAlign: 'center', color: 'var(--text-muted)' }}>加载中...</div>
             )}
           </Card>
         </Col>

--- a/frontend/src/pages/ICloud.tsx
+++ b/frontend/src/pages/ICloud.tsx
@@ -148,7 +148,7 @@ export default function ICloudPage() {
           <Badge
             count={account.alias_count}
             showZero
-            color="#0ea5e9"
+            color="#5b8db3"
             style={{ marginRight: 8 }}
           />
           <Text type="secondary">
@@ -554,11 +554,11 @@ function MessageBody({ item }: { item: ICloudMessage }) {
   const srcDoc = `<!doctype html><html><head><meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="script-src 'none'">
 <style>
-  html,body{margin:0;padding:16px;background:#fff;color:#1f1f1f;
+  html,body{margin:0;padding:16px;background:#f7f8fa;color:#2f3540;
     font:14px/1.7 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
     word-break:break-word;overflow-wrap:anywhere;}
   img,table{max-width:100%!important;height:auto;}
-  a{color:#1677ff;}
+  a{color:#3f6ea8;}
 </style></head><body>${html}</body></html>`
 
   return (
@@ -568,7 +568,7 @@ function MessageBody({ item }: { item: ICloudMessage }) {
       sandbox="allow-same-origin"
       srcDoc={srcDoc}
       onLoad={resize}
-      style={{ width: '100%', height, border: 0, borderRadius: 8, background: '#fff', display: 'block' }}
+      style={{ width: '100%', height, border: 0, borderRadius: 10, background: '#f7f8fa', display: 'block' }}
     />
   )
 }
@@ -657,8 +657,8 @@ function AliasInboxDrawer({ alias, onClose }: { alias: ICloudAlias | null; onClo
             style={{
               cursor: 'pointer',
               padding: '12px 16px',
-              borderInlineStart: `3px solid ${active ? 'var(--ant-color-primary, #1677ff)' : 'transparent'}`,
-              background: active ? 'var(--ant-color-fill-tertiary, rgba(255,255,255,0.06))' : undefined,
+              borderInlineStart: `3px solid ${active ? 'var(--accent)' : 'transparent'}`,
+              background: active ? 'var(--accent-soft)' : undefined,
             }}
           >
             {/* 这里刻意不用 Space：它会给每个子元素套一层 div，flex:1 落不到文本上，
@@ -734,7 +734,7 @@ function AliasInboxDrawer({ alias, onClose }: { alias: ICloudAlias | null; onClo
             style={{
               width: isNarrow ? '100%' : 320,
               flex: isNarrow ? 1 : '0 0 320px',
-              borderInlineEnd: isNarrow ? undefined : '1px solid var(--ant-color-split, rgba(255,255,255,0.12))',
+              borderInlineEnd: isNarrow ? undefined : '1px solid var(--border)',
               display: 'flex',
               flexDirection: 'column',
               minHeight: 0,

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -57,7 +57,7 @@ function LoginContent() {
 
   const cardStyle: React.CSSProperties = {
     width: 380,
-    boxShadow: '0 8px 32px rgba(0,0,0,0.18)',
+    boxShadow: '0 10px 30px rgba(0,0,0,0.28)',
     borderRadius: 12,
   }
 
@@ -66,7 +66,7 @@ function LoginContent() {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 100%)',
+    background: 'linear-gradient(160deg, var(--bg-layout) 0%, var(--bg-container) 100%)',
   }
 
   if (step === '2fa') {
@@ -76,7 +76,7 @@ function LoginContent() {
           style={cardStyle}
           title={
             <div style={{ textAlign: 'center', padding: '8px 0' }}>
-              <SafetyCertificateOutlined style={{ fontSize: 28, color: '#6366f1', marginBottom: 8, display: 'block' }} />
+              <SafetyCertificateOutlined style={{ fontSize: 28, color: 'var(--accent)', marginBottom: 8, display: 'block' }} />
               <div style={{ fontSize: 18, fontWeight: 700 }}>双因素验证</div>
               <Typography.Text type="secondary" style={{ fontSize: 13, fontWeight: 400 }}>
                 请输入验证器 App 中的 6 位验证码
@@ -123,7 +123,7 @@ function LoginContent() {
         style={cardStyle}
         title={
           <div style={{ textAlign: 'center', padding: '8px 0', background: 'transparent' }}>
-            <UserOutlined style={{ fontSize: 28, color: '#6366f1', marginBottom: 8, display: 'block' }} />
+            <UserOutlined style={{ fontSize: 28, color: 'var(--accent)', marginBottom: 8, display: 'block' }} />
             <div style={{ fontSize: 18, fontWeight: 700 }}>Account Manager</div>
             <Typography.Text type="secondary" style={{ fontSize: 13, fontWeight: 400 }}>
               请输入密码登录

--- a/frontend/src/pages/Proxies.tsx
+++ b/frontend/src/pages/Proxies.tsx
@@ -179,7 +179,7 @@ export default function Proxies() {
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div>
           <h1 style={{ fontSize: 24, fontWeight: 'bold', margin: 0 }}>代理管理</h1>
-          <p style={{ color: '#7a8ba3', marginTop: 4 }}>共 {proxies.length} 个代理</p>
+          <p style={{ color: 'var(--text-muted)', marginTop: 4 }}>共 {proxies.length} 个代理</p>
         </div>
         <Button icon={<ReloadOutlined spin={checking} />} onClick={check} loading={checking}>
           检测全部
@@ -211,7 +211,7 @@ export default function Proxies() {
 
       <Card>
         <div style={{ marginBottom: 12, display: 'flex', justifyContent: 'space-between' }}>
-          <div style={{ color: '#7a8ba3' }}>
+          <div style={{ color: 'var(--text-muted)' }}>
             已选中 {selectedRowKeys.length} 条
           </div>
           <Popconfirm

--- a/frontend/src/pages/RegisterTaskPage.tsx
+++ b/frontend/src/pages/RegisterTaskPage.tsx
@@ -246,7 +246,7 @@ export default function RegisterTaskPage() {
     <div style={{ maxWidth: 800 }}>
       <div style={{ marginBottom: 24 }}>
         <h1 style={{ fontSize: 24, fontWeight: 'bold', margin: 0 }}>注册任务</h1>
-        <p style={{ color: '#7a8ba3', marginTop: 4 }}>创建账号自动注册任务</p>
+        <p style={{ color: 'var(--text-muted)', marginTop: 4 }}>创建账号自动注册任务</p>
       </div>
 
       <Form form={form} layout="vertical" onFinish={submit} initialValues={{
@@ -665,21 +665,21 @@ export default function RegisterTaskPage() {
             <Descriptions.Item label="跳过">{task.skipped ?? 0}</Descriptions.Item>
           </Descriptions>
           {task.success != null && (
-            <div style={{ marginTop: 8, color: '#10b981' }}>
+            <div style={{ marginTop: 8, color: 'var(--success)' }}>
               <CheckCircleOutlined /> 成功 {task.success} 个
             </div>
           )}
           {task.errors?.length > 0 && (
             <div style={{ marginTop: 8 }}>
               {task.errors.map((e: string, i: number) => (
-                <div key={i} style={{ color: '#ef4444', marginBottom: 4 }}>
+                <div key={i} style={{ color: 'var(--danger)', marginBottom: 4 }}>
                   <CloseCircleOutlined /> {e}
                 </div>
               ))}
             </div>
           )}
           {task.error && (
-            <div style={{ marginTop: 8, color: '#ef4444' }}>
+            <div style={{ marginTop: 8, color: 'var(--danger)' }}>
               <CloseCircleOutlined /> {task.error}
             </div>
           )}

--- a/frontend/src/pages/RunningTasks.tsx
+++ b/frontend/src/pages/RunningTasks.tsx
@@ -213,16 +213,16 @@ export default function RunningTasks() {
                 format={() => `${done}/${total}`}
               />
               <Space size={8}>
-                <Text style={{ fontSize: 11, color: '#10b981' }}>
+                <Text style={{ fontSize: 11, color: 'var(--success)' }}>
                   ✓ 成功 {success}
                 </Text>
                 {failed > 0 && (
-                  <Text style={{ fontSize: 11, color: '#dc2626' }}>
+                  <Text style={{ fontSize: 11, color: 'var(--danger)' }}>
                     ✗ 失败 {failed}
                   </Text>
                 )}
                 {skipped > 0 && (
-                  <Text style={{ fontSize: 11, color: '#d97706' }}>
+                  <Text style={{ fontSize: 11, color: 'var(--warning)' }}>
                     → 跳过 {skipped}
                   </Text>
                 )}
@@ -283,7 +283,7 @@ export default function RunningTasks() {
         <div style={{ marginBottom: 24 }}>
           <Text
             strong
-            style={{ display: 'block', marginBottom: 8, fontSize: 13, color: '#6366f1' }}
+            style={{ display: 'block', marginBottom: 8, fontSize: 13, color: 'var(--accent)' }}
           >
             进行中 ({activeTasks.length})
           </Text>
@@ -296,7 +296,7 @@ export default function RunningTasks() {
         <div>
           <Text
             strong
-            style={{ display: 'block', marginBottom: 8, fontSize: 13, color: '#6b7280' }}
+            style={{ display: 'block', marginBottom: 8, fontSize: 13, color: 'var(--text-muted)' }}
           >
             已完成 ({finishedTasks.length})
           </Text>

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -583,7 +583,7 @@ function ConfigField({ field }: { field: FieldConfig }) {
 
 function ConfigSection({ section }: { section: SectionConfig }) {
   return (
-    <Card title={section.title} extra={section.desc && <span style={{ fontSize: 12, color: '#7a8ba3' }}>{section.desc}</span>} style={{ marginBottom: 16 }}>
+    <Card title={section.title} extra={section.desc && <span style={{ fontSize: 12, color: 'var(--text-muted)' }}>{section.desc}</span>} style={{ marginBottom: 16 }}>
       {section.fields.map((field) => (
         <ConfigField key={field.key} field={field} />
       ))}
@@ -612,7 +612,7 @@ function CFWorkerDomainPoolSection({ form }: { form: any }) {
   return (
     <Card
       title="CF Worker 域名池"
-      extra={<span style={{ fontSize: 12, color: '#7a8ba3' }}>注册时会从已启用域名中随机选择一个</span>}
+      extra={<span style={{ fontSize: 12, color: 'var(--text-muted)' }}>注册时会从已启用域名中随机选择一个</span>}
       style={{ marginBottom: 16 }}
     >
       <Form.List name="cfworker_domains">
@@ -826,13 +826,13 @@ function SolverStatus() {
       >
         <Space size={8}>
           {running === null ? (
-            <SyncOutlined spin style={{ color: '#7a8ba3' }} />
+            <SyncOutlined spin style={{ color: 'var(--text-muted)' }} />
           ) : running ? (
-            <CheckCircleOutlined style={{ color: '#10b981' }} />
+            <CheckCircleOutlined style={{ color: 'var(--success)' }} />
           ) : (
-            <CloseCircleOutlined style={{ color: '#ef4444' }} />
+            <CloseCircleOutlined style={{ color: 'var(--danger)' }} />
           )}
-          <span style={{ color: running ? '#10b981' : '#7a8ba3', fontWeight: 500 }}>
+          <span style={{ color: running ? 'var(--success)' : 'var(--text-muted)', fontWeight: 500 }}>
             {running === null ? '检测中' : running ? '运行中' : '未运行'}
           </span>
         </Space>
@@ -977,7 +977,7 @@ function IntegrationsPanel() {
         cancelText="取消"
         width={760}
       >
-        <Typography.Paragraph style={{ marginBottom: 8, color: resultModal.ok ? '#10b981' : '#ef4444' }}>
+        <Typography.Paragraph style={{ marginBottom: 8, color: resultModal.ok ? 'var(--success)' : 'var(--danger)' }}>
           {resultModal.ok ? '操作已完成。' : '操作失败。'}
         </Typography.Paragraph>
         <pre
@@ -987,7 +987,7 @@ function IntegrationsPanel() {
             overflow: 'auto',
             padding: 12,
             borderRadius: 8,
-            background: 'rgba(127,127,127,0.08)',
+            background: 'var(--bg-subtle)',
             fontSize: 12,
             lineHeight: 1.5,
             whiteSpace: 'pre-wrap',
@@ -1048,7 +1048,7 @@ function IntegrationsPanel() {
             {item.management_url ? <div>管理页：<Typography.Text copyable>{item.management_url}</Typography.Text></div> : null}
             {item.management_key ? <div>登录口令：<Typography.Text copyable>{item.management_key}</Typography.Text></div> : null}
             <div>日志：<Typography.Text copyable>{item.log_path}</Typography.Text></div>
-            {item.last_error ? <div style={{ color: '#ef4444' }}>最近错误：{item.last_error}</div> : null}
+            {item.last_error ? <div style={{ color: 'var(--danger)' }}>最近错误：{item.last_error}</div> : null}
             <Space wrap>
               {item.management_url ? (
                 <Button onClick={() => window.open(item.management_url, '_blank')}>
@@ -1573,7 +1573,7 @@ export default function Settings() {
       ) : null}
       <div>
         <h1 style={{ fontSize: 24, fontWeight: 'bold', margin: 0 }}>全局配置</h1>
-        <p style={{ color: '#7a8ba3', marginTop: 4 }}>配置将持久化保存，注册任务自动使用</p>
+        <p style={{ color: 'var(--text-muted)', marginTop: 4 }}>配置将持久化保存，注册任务自动使用</p>
       </div>
 
       <div style={{ display: 'flex', gap: 24 }}>

--- a/frontend/src/pages/TaskHistory.tsx
+++ b/frontend/src/pages/TaskHistory.tsx
@@ -117,7 +117,7 @@ export default function TaskHistory() {
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <div>
           <h1 style={{ fontSize: 24, fontWeight: 'bold', margin: 0 }}>任务历史</h1>
-          <p style={{ color: '#7a8ba3', marginTop: 4 }}>注册任务执行记录</p>
+          <p style={{ color: 'var(--text-muted)', marginTop: 4 }}>注册任务执行记录</p>
         </div>
         <Space>
           <Text type="secondary">{total} 条记录</Text>

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,52 +1,214 @@
 import { theme } from 'antd'
 
-const darkTheme = {
-  token: {
-    colorPrimary: '#6366f1',
-    colorBgBase: '#1c1f2e',
-    colorTextBase: '#f1f5f9',
-    colorBgContainer: '#1c1f2e',
-    colorBgElevated: '#252836',
-    colorBorder: 'rgba(255,255,255,0.15)',
-    borderRadius: 8,
-    colorText: '#f1f5f9',
-    colorTextSecondary: '#b0bcd4',
-    colorTextTertiary: '#7a8ba3',
-    colorBgLayout: '#13151e',
-    colorBgSpotlight: 'rgba(99,102,241,0.2)',
-  },
-  components: {
-    Layout: {
-      siderBg: '#1c1f2e',
-      triggerBg: '#1c1f2e',
-      triggerColor: '#f1f5f9',
-    },
-  },
-  algorithm: theme.darkAlgorithm,
+export type ThemeMode = 'dark' | 'light'
+
+/**
+ * 界面用色统一在这里定义：antd token 与 CSS 变量共用同一份，
+ * 页面里的内联样式一律写 var(--x)，切主题时不用改组件。
+ */
+interface Palette {
+  bgLayout: string
+  bgContainer: string
+  bgElevated: string
+  bgSubtle: string
+  border: string
+  borderStrong: string
+  text: string
+  textSecondary: string
+  textMuted: string
+  accent: string
+  accentHover: string
+  accentSoft: string
+  success: string
+  successSoft: string
+  warning: string
+  warningSoft: string
+  danger: string
+  dangerSoft: string
+  logBg: string
+  logBorder: string
+  logText: string
+  logMuted: string
+  logSuccess: string
+  logWarning: string
+  logDanger: string
+  selectionBg: string
+  spotlightBg: string
 }
 
-const lightTheme = {
-  token: {
-    colorPrimary: '#4f46e5',
-    colorBgBase: '#ffffff',
-    colorTextBase: '#0f172a',
-    colorBgContainer: '#ffffff',
-    colorBgElevated: '#ffffff',
-    colorBorder: 'rgba(0,0,0,0.1)',
-    borderRadius: 8,
-    colorText: '#0f172a',
-    colorTextSecondary: '#475569',
-    colorTextTertiary: '#94a3b8',
-    colorBgLayout: '#f8fafc',
-  },
-  components: {
-    Layout: {
-      siderBg: '#ffffff',
-      triggerBg: '#ffffff',
-      triggerColor: '#0f172a',
-    },
-  },
-  algorithm: theme.defaultAlgorithm,
+const darkPalette: Palette = {
+  bgLayout: '#161922',
+  bgContainer: '#1e212c',
+  bgElevated: '#262a36',
+  bgSubtle: 'rgba(255,255,255,0.045)',
+  border: 'rgba(255,255,255,0.09)',
+  borderStrong: 'rgba(255,255,255,0.14)',
+  text: '#d7dce5',
+  textSecondary: '#a4adbd',
+  textMuted: '#7b8595',
+  accent: '#5f82b8',
+  accentHover: '#7396c8',
+  accentSoft: 'rgba(95,130,184,0.16)',
+  success: '#6cbf9a',
+  successSoft: 'rgba(108,191,154,0.14)',
+  warning: '#d3a26b',
+  warningSoft: 'rgba(211,162,107,0.14)',
+  danger: '#cf8181',
+  dangerSoft: 'rgba(207,129,129,0.14)',
+  logBg: '#191c24',
+  logBorder: 'rgba(255,255,255,0.07)',
+  logText: '#c3cad6',
+  logMuted: '#79828f',
+  logSuccess: '#7fc2a1',
+  logWarning: '#d7a86e',
+  logDanger: '#d48c8c',
+  selectionBg: 'rgba(95,130,184,0.38)',
+  spotlightBg: '#2b3040',
 }
 
-export { darkTheme, lightTheme }
+const lightPalette: Palette = {
+  bgLayout: '#f5f6f8',
+  bgContainer: '#ffffff',
+  bgElevated: '#ffffff',
+  bgSubtle: 'rgba(15,23,42,0.035)',
+  border: 'rgba(15,23,42,0.09)',
+  borderStrong: 'rgba(15,23,42,0.14)',
+  text: '#2c3440',
+  textSecondary: '#5b6675',
+  textMuted: '#8a94a3',
+  accent: '#4a6fa5',
+  accentHover: '#5b81b8',
+  accentSoft: 'rgba(74,111,165,0.12)',
+  success: '#3f9b76',
+  successSoft: 'rgba(63,155,118,0.12)',
+  warning: '#b0803a',
+  warningSoft: 'rgba(176,128,58,0.12)',
+  danger: '#c06a6a',
+  dangerSoft: 'rgba(192,106,106,0.12)',
+  logBg: '#fbfcfd',
+  logBorder: 'rgba(15,23,42,0.08)',
+  logText: '#3a4351',
+  logMuted: '#8a94a3',
+  logSuccess: '#3f8f6d',
+  logWarning: '#a97b34',
+  logDanger: '#b46060',
+  selectionBg: 'rgba(74,111,165,0.22)',
+  spotlightBg: '#3a4353',
+}
+
+function buildTheme(palette: Palette, algorithm: typeof theme.darkAlgorithm) {
+  return {
+    token: {
+      colorPrimary: palette.accent,
+      colorInfo: palette.accent,
+      colorSuccess: palette.success,
+      colorWarning: palette.warning,
+      colorError: palette.danger,
+      colorBgBase: palette.bgContainer,
+      colorTextBase: palette.text,
+      colorBgContainer: palette.bgContainer,
+      colorBgElevated: palette.bgElevated,
+      colorBgLayout: palette.bgLayout,
+      colorBorder: palette.borderStrong,
+      colorBorderSecondary: palette.border,
+      borderRadius: 10,
+      colorText: palette.text,
+      colorTextSecondary: palette.textSecondary,
+      colorTextTertiary: palette.textMuted,
+      colorBgSpotlight: palette.spotlightBg,
+      controlOutline: palette.accentSoft,
+    },
+    components: {
+      Layout: {
+        siderBg: palette.bgContainer,
+        triggerBg: palette.bgElevated,
+        triggerColor: palette.textSecondary,
+      },
+      Menu: {
+        itemColor: palette.textSecondary,
+        itemHoverBg: palette.bgSubtle,
+        itemHoverColor: palette.text,
+        itemSelectedBg: palette.accentSoft,
+        itemSelectedColor: palette.text,
+        subMenuItemBg: 'transparent',
+      },
+      Card: {
+        headerBg: 'transparent',
+        colorBorderSecondary: palette.border,
+      },
+      Table: {
+        headerBg: palette.bgSubtle,
+        headerColor: palette.textSecondary,
+        headerSplitColor: 'transparent',
+        rowHoverBg: palette.bgSubtle,
+        borderColor: palette.border,
+      },
+      Modal: {
+        contentBg: palette.bgElevated,
+        headerBg: palette.bgElevated,
+        titleColor: palette.text,
+      },
+      Tag: {
+        defaultBg: palette.bgSubtle,
+        defaultColor: palette.textSecondary,
+      },
+      Button: {
+        primaryShadow: 'none',
+        defaultShadow: 'none',
+        dangerShadow: 'none',
+      },
+      Segmented: {
+        itemSelectedBg: palette.accentSoft,
+        itemSelectedColor: palette.text,
+      },
+    },
+    algorithm,
+  }
+}
+
+const darkTheme = buildTheme(darkPalette, theme.darkAlgorithm)
+const lightTheme = buildTheme(lightPalette, theme.defaultAlgorithm)
+
+const CSS_VAR_NAMES: Record<keyof Palette, string> = {
+  bgLayout: '--bg-layout',
+  bgContainer: '--bg-container',
+  bgElevated: '--bg-elevated',
+  bgSubtle: '--bg-subtle',
+  border: '--border',
+  borderStrong: '--border-strong',
+  text: '--text',
+  textSecondary: '--text-secondary',
+  textMuted: '--text-muted',
+  accent: '--accent',
+  accentHover: '--accent-hover',
+  accentSoft: '--accent-soft',
+  success: '--success',
+  successSoft: '--success-soft',
+  warning: '--warning',
+  warningSoft: '--warning-soft',
+  danger: '--danger',
+  dangerSoft: '--danger-soft',
+  logBg: '--log-bg',
+  logBorder: '--log-border',
+  logText: '--log-text',
+  logMuted: '--log-muted',
+  logSuccess: '--log-success',
+  logWarning: '--log-warning',
+  logDanger: '--log-danger',
+  selectionBg: '--selection-bg',
+  spotlightBg: '--spotlight-bg',
+}
+
+/** 把当前主题写成 CSS 变量，登录页等没有 ConfigProvider 的地方也能取到同一套色。 */
+export function applyThemeVars(mode: ThemeMode) {
+  const palette = mode === 'light' ? lightPalette : darkPalette
+  const root = document.documentElement
+  for (const [key, name] of Object.entries(CSS_VAR_NAMES)) {
+    root.style.setProperty(name, palette[key as keyof Palette])
+  }
+  root.style.setProperty('--sider-trigger-border', palette.border)
+  root.classList.toggle('light', mode === 'light')
+  root.style.colorScheme = mode
+}
+
+export { darkTheme, lightTheme, darkPalette, lightPalette }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
前端整体配色调柔和，重点改善注册 / 补 RT 日志弹窗在暗色主题下的刺眼感。

## 主要改动

- 调色板收敛到 `frontend/src/theme.ts`，同时喂 antd token 与 CSS 变量
- `TaskLogPanel` 控制台从写死的白底黑字改为跟随主题的深色柔和底；成功/失败/警告行色降饱和
- 正文字色、主色、边框、成功/警告/失败色整体降对比；圆角略放大
- 登录页、iCloud 邮件 iframe、遮罩与投影一并收软

已部署到线上，刷新即可预览。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35260470-e43e-4abe-a670-08823bc564b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35260470-e43e-4abe-a670-08823bc564b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

