### PR TITLE
微软邮箱池不再交出已经注册过的地址

### DIFF
--- a/core/base_mailbox.py
+++ b/core/base_mailbox.py
@@ -3621,20 +3621,34 @@ class OutlookMailbox(BaseMailbox):
         return bool(str(extra.get("mailapi_url") or "").strip())
 
     def _pop_account(self) -> dict:
+        from sqlalchemy import func
         from sqlmodel import Session, select
-        from core.db import engine, OutlookAccountModel
+        from core.db import engine, AccountModel, OutlookAccountModel
 
         with OutlookMailbox._pop_lock:
             with Session(engine) as session:
-                account = (
-                    session.exec(
-                        select(OutlookAccountModel)
-                        .where(OutlookAccountModel.enabled == True)
-                        .order_by(OutlookAccountModel.id)
-                    )
-                    .first()
+                # 池子是消费型的，取走即删；但导入时把用过的地址又写回来（比如
+                # 重新导入一份含旧别名的清单）就会拿到已经注册过的邮箱，再去注册
+                # 必然撞 "邮箱已被占用"。这里按 accounts 表兜一道，注册过的直接跳过。
+                registered = select(func.lower(AccountModel.email))
+                query = (
+                    select(OutlookAccountModel)
+                    .where(OutlookAccountModel.enabled == True)
+                    .where(func.lower(OutlookAccountModel.email).notin_(registered))
+                    .order_by(OutlookAccountModel.id)
                 )
+                account = session.exec(query).first()
                 if not account:
+                    total_left = session.exec(
+                        select(func.count(OutlookAccountModel.id)).where(
+                            OutlookAccountModel.enabled == True
+                        )
+                    ).one()
+                    if total_left:
+                        raise RuntimeError(
+                            f"微软邮箱账号池里剩下的 {total_left} 个地址都已经注册过了，"
+                            "请导入新的邮箱"
+                        )
                     raise RuntimeError("微软邮箱账号池为空，请先在设置页批量导入")
 
                 payload = {

--- a/services/mail_imports/microsoft_import_rules.py
+++ b/services/mail_imports/microsoft_import_rules.py
@@ -32,6 +32,11 @@ class MicrosoftImportRowParser(Protocol):
         ...
 
 
+def normalize_import_email(value: str) -> str:
+    """查重一律按小写比，邮箱大小写不同不该被当成两个地址。"""
+    return str(value or "").strip().lower()
+
+
 def _is_valid_email(email: str) -> bool:
     return "@" in str(email or "").strip()
 
@@ -146,9 +151,34 @@ class DuplicateMicrosoftMailboxRule:
         record: MicrosoftMailImportRecord,
         context: dict[str, Any],
     ) -> dict[str, Any]:
-        existing_emails = context.get("existing_emails") or set()
-        if record.email in existing_emails:
+        existing_emails = {
+            normalize_import_email(email) for email in context.get("existing_emails") or set()
+        }
+        if normalize_import_email(record.email) in existing_emails:
             return {"ok": False, "message": f"行 {record.line_number}: 邮箱已存在: {record.email}"}
+        return {"ok": True, "message": "ok"}
+
+
+class RegisteredMicrosoftMailboxRule:
+    """挡掉已经注册成功过的地址。
+
+    池子取号时会把行删掉，所以池内查重看不见"用过的"。重新导入一份含旧别名的
+    清单就会把注册过的地址又塞回池子，下次注册必然撞平台的"邮箱已被占用"。
+    """
+
+    def evaluate(
+        self,
+        record: MicrosoftMailImportRecord,
+        context: dict[str, Any],
+    ) -> dict[str, Any]:
+        registered_emails = {
+            normalize_import_email(email) for email in context.get("registered_emails") or set()
+        }
+        if normalize_import_email(record.email) in registered_emails:
+            return {
+                "ok": False,
+                "message": f"行 {record.line_number}: 邮箱已注册过账号，不再入池: {record.email}",
+            }
         return {"ok": True, "message": "ok"}
 
 

--- a/services/mail_imports/providers.py
+++ b/services/mail_imports/providers.py
@@ -14,7 +14,7 @@ from core.applemail_pool import (
     save_applemail_pool_json,
 )
 from core.config_store import config_store
-from core.db import OutlookAccountModel, engine
+from core.db import AccountModel, OutlookAccountModel, engine
 
 from .base import BaseMailImportStrategy
 from .microsoft_import_rules import (
@@ -24,6 +24,8 @@ from .microsoft_import_rules import (
     MicrosoftMailImportRecord,
     MailApiUrlFormatRule,
     MicrosoftMailImportRuleEngine,
+    RegisteredMicrosoftMailboxRule,
+    normalize_import_email,
 )
 from .schemas import (
     MailImportBatchDeleteRequest,
@@ -288,19 +290,22 @@ class MicrosoftMailImportStrategy(BaseMailImportStrategy):
         enabled: bool,
         alias_count: int,
         include_original: bool,
+        taken_emails: set[str] | None = None,
     ) -> list[MicrosoftMailImportRecord]:
         if not enabled:
             return records
 
         expanded: list[MicrosoftMailImportRecord] = []
         target_count = max(1, min(int(alias_count or 1), 5))
+        # 别名是随机拼的，撞上池内已有或注册过的地址就得换一个再拼
+        taken = {normalize_import_email(email) for email in taken_emails or set()}
 
         for record in records:
             emails: list[str] = []
-            seen_emails: set[str] = set()
+            seen_emails: set[str] = set(taken)
             if include_original:
                 emails.append(record.email)
-                seen_emails.add(record.email)
+                seen_emails.add(normalize_import_email(record.email))
 
             aliases: list[str] = []
             max_attempts = max(20, target_count * 20)
@@ -308,9 +313,9 @@ class MicrosoftMailImportStrategy(BaseMailImportStrategy):
             while len(aliases) < target_count and attempts < max_attempts:
                 candidate = MicrosoftMailImportStrategy._generate_alias_email(record.email)
                 attempts += 1
-                if candidate in seen_emails:
+                if normalize_import_email(candidate) in seen_emails:
                     continue
-                seen_emails.add(candidate)
+                seen_emails.add(normalize_import_email(candidate))
                 aliases.append(candidate)
 
             emails.extend(aliases)
@@ -432,14 +437,21 @@ class MicrosoftMailImportStrategy(BaseMailImportStrategy):
 
         with Session(engine) as session:
             existing_emails = {
-                str(email or "").strip()
+                normalize_import_email(email)
                 for email in session.exec(select(OutlookAccountModel.email)).all()
+                if str(email or "").strip()
+            }
+            registered_emails = {
+                normalize_import_email(email)
+                for email in session.exec(select(AccountModel.email)).all()
+                if str(email or "").strip()
             }
 
         row_parser = AutoDetectRowParser()
         rule_engine = MicrosoftMailImportRuleEngine(
             rules=[
                 DuplicateMicrosoftMailboxRule(),
+                RegisteredMicrosoftMailboxRule(),
                 MailApiUrlFormatRule(),
             ]
         )
@@ -452,15 +464,18 @@ class MicrosoftMailImportStrategy(BaseMailImportStrategy):
                 errors.append(str(exc))
                 continue
 
-            if record.email in batch_seen_emails:
+            if normalize_import_email(record.email) in batch_seen_emails:
                 failed += 1
                 errors.append(f"行 {line_number}: 导入内容存在重复邮箱: {record.email}")
                 continue
-            batch_seen_emails.add(record.email)
+            batch_seen_emails.add(normalize_import_email(record.email))
 
             duplicate_check = rule_engine.evaluate(
                 record,
-                {"existing_emails": existing_emails},
+                {
+                    "existing_emails": existing_emails,
+                    "registered_emails": registered_emails,
+                },
             )
             if not duplicate_check.get("ok"):
                 failed += 1
@@ -476,6 +491,7 @@ class MicrosoftMailImportStrategy(BaseMailImportStrategy):
             enabled=alias_enabled,
             alias_count=alias_count,
             include_original=alias_include_original,
+            taken_emails=existing_emails | registered_emails,
         )
 
         oauth_records = [
@@ -537,7 +553,7 @@ class MicrosoftMailImportStrategy(BaseMailImportStrategy):
                     session.add(account)
                     session.commit()
                     session.refresh(account)
-                    existing_emails.add(record.email)
+                    existing_emails.add(normalize_import_email(record.email))
                     accounts.append({
                         "id": account.id,
                         "email": account.email,

--- a/tests/test_mail_imports_service.py
+++ b/tests/test_mail_imports_service.py
@@ -95,6 +95,27 @@ class MailImportServiceTests(unittest.TestCase):
         self.assertFalse(result["ok"])
         self.assertEqual(result["message"], "行 2: 邮箱已存在: demo@outlook.com")
 
+    def test_registered_email_rule_keeps_used_address_out_of_the_pool(self):
+        rules_module = load_microsoft_import_rules_module()
+        RegisteredMicrosoftMailboxRule = rules_module.RegisteredMicrosoftMailboxRule
+        MicrosoftMailImportRecord = rules_module.MicrosoftMailImportRecord
+
+        rule = RegisteredMicrosoftMailboxRule()
+        record = MicrosoftMailImportRecord(
+            line_number=3,
+            email="Phillip94426+wbuuax@outlook.com",
+            password="password",
+            client_id="client-id",
+            refresh_token="refresh-token",
+        )
+
+        result = rule.evaluate(
+            record,
+            {"registered_emails": {"phillip94426+wbuuax@outlook.com"}},
+        )
+        self.assertFalse(result["ok"])
+        self.assertIn("已注册过账号", result["message"])
+
     def test_microsoft_mailbox_availability_rule_rejects_service_abuse_mode(self):
         rules_module = load_microsoft_import_rules_module()
         MicrosoftMailImportRecord = rules_module.MicrosoftMailImportRecord
@@ -303,6 +324,119 @@ class MailImportServiceTests(unittest.TestCase):
                             ]
                         ),
                     )
+            finally:
+                test_engine.dispose()
+
+
+    def test_microsoft_strategy_skips_addresses_that_already_registered(self):
+        from core.db import AccountModel
+        from services.mail_imports.schemas import MailImportExecuteRequest
+        from services.mail_imports.providers import MicrosoftMailImportStrategy
+
+        strategy = MicrosoftMailImportStrategy()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_engine = create_engine(f"sqlite:///{Path(tmp_dir) / 'mail-imports.db'}")
+            SQLModel.metadata.create_all(test_engine)
+
+            from sqlmodel import Session
+
+            with Session(test_engine) as session:
+                session.add(
+                    AccountModel(
+                        platform="chatgpt",
+                        email="used+wbuuax@outlook.com",
+                        password="pwd",
+                    )
+                )
+                session.commit()
+
+            try:
+                with patch("services.mail_imports.providers.engine", test_engine), \
+                     patch("services.mail_imports.providers.OutlookMailbox") as mailbox_cls:
+                    mailbox = mailbox_cls.return_value
+                    mailbox.probe_oauth_availability.return_value = {
+                        "ok": True,
+                        "reason": "ok",
+                        "message": "微软邮箱可用性检测通过",
+                    }
+
+                    response = strategy.execute(
+                        MailImportExecuteRequest(
+                            type="microsoft",
+                            content=(
+                                "used+wbuuax@outlook.com----password----client-a----refresh-a\n"
+                                "fresh@outlook.com----password----client-b----refresh-b"
+                            ),
+                        )
+                    )
+
+                    self.assertEqual(response.summary.success, 1)
+                    self.assertEqual(response.summary.failed, 1)
+                    self.assertIn("已注册过账号", " ".join(response.errors))
+                    self.assertEqual(
+                        [item.email for item in response.snapshot.items],
+                        ["fresh@outlook.com"],
+                    )
+            finally:
+                test_engine.dispose()
+
+    def test_pool_pop_walks_past_addresses_that_already_registered(self):
+        from sqlmodel import Session, select
+        from core.base_mailbox import OutlookMailbox
+        from core.db import AccountModel, OutlookAccountModel
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_engine = create_engine(f"sqlite:///{Path(tmp_dir) / 'pool.db'}")
+            SQLModel.metadata.create_all(test_engine)
+
+            try:
+                with Session(test_engine) as session:
+                    session.add(
+                        AccountModel(
+                            platform="chatgpt",
+                            email="Used+wbuuax@outlook.com",
+                            password="pwd",
+                        )
+                    )
+                    session.add(
+                        OutlookAccountModel(email="used+wbuuax@outlook.com", password="pwd")
+                    )
+                    session.add(OutlookAccountModel(email="fresh@outlook.com", password="pwd"))
+                    session.commit()
+
+                with patch("core.db.engine", test_engine):
+                    payload = OutlookMailbox()._pop_account()
+
+                self.assertEqual(payload["email"], "fresh@outlook.com")
+
+                with Session(test_engine) as session:
+                    left = sorted(
+                        row.email for row in session.exec(select(OutlookAccountModel)).all()
+                    )
+                self.assertEqual(left, ["used+wbuuax@outlook.com"])
+            finally:
+                test_engine.dispose()
+
+    def test_pool_pop_says_so_when_everything_left_is_already_registered(self):
+        from sqlmodel import Session
+        from core.base_mailbox import OutlookMailbox
+        from core.db import AccountModel, OutlookAccountModel
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_engine = create_engine(f"sqlite:///{Path(tmp_dir) / 'pool-used.db'}")
+            SQLModel.metadata.create_all(test_engine)
+
+            try:
+                with Session(test_engine) as session:
+                    session.add(
+                        AccountModel(platform="chatgpt", email="used@outlook.com", password="pwd")
+                    )
+                    session.add(OutlookAccountModel(email="used@outlook.com", password="pwd"))
+                    session.commit()
+
+                with patch("core.db.engine", test_engine):
+                    with self.assertRaisesRegex(RuntimeError, "都已经注册过了"):
+                        OutlookMailbox()._pop_account()
             finally:
                 test_engine.dispose()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
修复微软邮箱池会把已注册地址再次交给注册任务的问题。

池子是消费型的，取号后行被删除；导入查重又不看 `accounts` 表，重新导入旧清单（含 `+xxxxxx` 别名）就会把注册过的地址送回池里。

- 取号时跳过 `accounts` 里已有的地址
- 导入查重纳入已注册地址，并覆盖别名展开之后
- 池中只剩已注册地址时给出明确提示

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35260470-e43e-4abe-a670-08823bc564b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35260470-e43e-4abe-a670-08823bc564b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

