### PR TITLE
去掉界面上的 Account Manager 字样

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -61,7 +61,7 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1280,
     height: 800,
-    title: 'Account Manager',
+    title: 'any-auto-register',
     webPreferences: {
       contextIsolation: true,
     },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -162,18 +162,6 @@ function AppContent() {
             }}
           >
             <DashboardOutlined style={{ fontSize: 20, color: currentTheme.token?.colorPrimary }} />
-            {!collapsed && (
-              <span
-                style={{
-                  marginLeft: 8,
-                  fontWeight: 600,
-                  fontSize: 14,
-                  color: currentTheme.token?.colorText,
-                }}
-              >
-                Account Manager
-              </span>
-            )}
           </div>
           <Menu
             mode="inline"

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -124,10 +124,7 @@ function LoginContent() {
         title={
           <div style={{ textAlign: 'center', padding: '8px 0', background: 'transparent' }}>
             <UserOutlined style={{ fontSize: 28, color: '#6366f1', marginBottom: 8, display: 'block' }} />
-            <div style={{ fontSize: 18, fontWeight: 700 }}>Account Manager</div>
-            <Typography.Text type="secondary" style={{ fontSize: 13, fontWeight: 400 }}>
-              请输入密码登录
-            </Typography.Text>
+            <div style={{ fontSize: 18, fontWeight: 700 }}>请输入密码登录</div>
           </div>
         }
       >

--- a/main.py
+++ b/main.py
@@ -76,7 +76,7 @@ async def lifespan(app: FastAPI):
     stop()
 
 
-app = FastAPI(title="Account Manager", version="1.0.0", lifespan=lifespan)
+app = FastAPI(title="any-auto-register", version="1.0.0", lifespan=lifespan)
 
 
 @app.middleware("http")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
去掉界面上的 “Account Manager” 文案。

- 侧栏顶部只保留图标
- 登录页去掉品牌标题行
- Electron / FastAPI 标题改为 `any-auto-register`（不能留空）

已部署到线上。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35260470-e43e-4abe-a670-08823bc564b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35260470-e43e-4abe-a670-08823bc564b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

