### PR TITLE
隐私邮箱支持批量删除和导出

### DIFF
--- a/api/icloud.py
+++ b/api/icloud.py
@@ -111,6 +111,11 @@ class GenerateAliasRequest(BaseModel):
     count: int = Field(default=1, ge=1, le=5)
 
 
+class BatchDeleteAliasRequest(BaseModel):
+    ids: list[int] = Field(default_factory=list)
+    remote: bool = True
+
+
 def _login_response(state: LoginState) -> dict[str, Any]:
     """登录完成时顺带把主号落库，让前端一次调用即可拿到最终结果。"""
     payload = state.to_dict()
@@ -266,6 +271,14 @@ def generate_aliases(body: GenerateAliasRequest):
     except ICloudError as error:
         raise _http_error(error) from error
     return {"items": created}
+
+
+@router.post("/aliases/batch-delete")
+def batch_delete_aliases(body: BatchDeleteAliasRequest):
+    if not body.ids:
+        raise HTTPException(400, "请先选择要删除的隐私邮箱")
+    result = icloud_service.delete_aliases(body.ids, remote=body.remote)
+    return {"ok": not result["failed"], **result}
 
 
 @router.delete("/aliases/{alias_id}")

--- a/frontend/src/api/icloud.ts
+++ b/frontend/src/api/icloud.ts
@@ -189,6 +189,19 @@ export function deleteICloudAlias(id: number, remote = true): Promise<{ ok: bool
   return apiFetch(`/icloud/aliases/${id}?remote=${remote}`, { method: 'DELETE' })
 }
 
+export interface ICloudBatchDeleteResult {
+  ok: boolean
+  deleted: number[]
+  failed: { alias_id: number; code: string; message: string }[]
+}
+
+export function batchDeleteICloudAliases(
+  ids: number[],
+  remote = true,
+): Promise<ICloudBatchDeleteResult> {
+  return post<ICloudBatchDeleteResult>('/icloud/aliases/batch-delete', { ids, remote })
+}
+
 export async function listICloudAliasMessages(
   aliasId: number,
   limit = 20,

--- a/frontend/src/lib/icloud.ts
+++ b/frontend/src/lib/icloud.ts
@@ -15,6 +15,33 @@ export function getICloudRegionLabel(region?: string): string {
   return ICLOUD_REGION_OPTIONS.find((item) => item.value === region)?.label ?? region ?? '-'
 }
 
+/**
+ * 导出格式沿用仓库里邮箱池导入那套 `----` 分隔：
+ *   self    → 隐私邮箱----隐私邮箱（默认，粘到只认「邮箱----邮箱地址」的地方）
+ *   account → 隐私邮箱----所属主号（想知道每个别名挂在哪个 Apple ID 下时用）
+ */
+export type AliasExportMode = 'self' | 'account'
+
+export const ALIAS_EXPORT_FILENAME = 'icloud_aliases.txt'
+
+export function formatAliasExport(
+  aliases: { address: string; account_email: string }[],
+  mode: AliasExportMode = 'self',
+): string {
+  return aliases
+    .map((alias) => `${alias.address}----${mode === 'account' ? alias.account_email : alias.address}`)
+    .join('\n')
+}
+
+export function downloadTextFile(filename: string, content: string): void {
+  const url = URL.createObjectURL(new Blob([content], { type: 'text/plain;charset=utf-8' }))
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+
 export function formatDateTime(value?: string | null): string {
   if (!value) return '-'
   const parsed = new Date(value)

--- a/frontend/src/pages/ICloud.tsx
+++ b/frontend/src/pages/ICloud.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Card,
   Drawer,
+  Dropdown,
   Empty,
   Form,
   Grid,
@@ -26,6 +27,8 @@ import {
 import {
   CloudOutlined,
   DeleteOutlined,
+  DownOutlined,
+  DownloadOutlined,
   InboxOutlined,
   LoginOutlined,
   PaperClipOutlined,
@@ -35,6 +38,7 @@ import {
   SyncOutlined,
 } from '@ant-design/icons'
 import {
+  batchDeleteICloudAliases,
   deleteICloudAccount,
   deleteICloudAlias,
   generateICloudAliases,
@@ -53,10 +57,14 @@ import {
   DEFAULT_ICLOUD_IMAP_HOST,
   DEFAULT_ICLOUD_IMAP_PORT,
   ICLOUD_HOURLY_ALIAS_LIMIT,
+  ALIAS_EXPORT_FILENAME,
   ICLOUD_REGION_OPTIONS,
+  downloadTextFile,
+  formatAliasExport,
   formatDateTime,
   formatRelativeTime,
   getICloudRegionLabel,
+  type AliasExportMode,
 } from '@/lib/icloud'
 
 const { Text, Paragraph, Title } = Typography
@@ -72,6 +80,8 @@ export default function ICloudPage() {
   const [generateOpen, setGenerateOpen] = useState(false)
   const [filterAccountId, setFilterAccountId] = useState<number | undefined>()
   const [inboxAlias, setInboxAlias] = useState<ICloudAlias | null>(null)
+  const [selectedAliasIds, setSelectedAliasIds] = useState<React.Key[]>([])
+  const [batchDeleting, setBatchDeleting] = useState(false)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -110,6 +120,46 @@ export default function ICloudPage() {
     () => accounts.map((account) => ({ value: account.id, label: account.email })),
     [accounts],
   )
+
+  // 换主号筛选后原来选中的行已经不在表里了，留着只会误删
+  useEffect(() => {
+    setSelectedAliasIds([])
+  }, [filterAccountId])
+
+  // 没勾选就按当前筛选出来的全部算，跟账号页导出的口径一致
+  const targetAliases = useMemo(() => {
+    if (selectedAliasIds.length === 0) return aliases
+    const picked = new Set(selectedAliasIds.map(Number))
+    return aliases.filter((alias) => picked.has(alias.id))
+  }, [aliases, selectedAliasIds])
+
+  const handleBatchDelete = async () => {
+    const ids = selectedAliasIds.map(Number).filter((id) => Number.isInteger(id) && id > 0)
+    if (ids.length === 0) return
+    setBatchDeleting(true)
+    try {
+      const result = await batchDeleteICloudAliases(ids)
+      if (result.failed.length === 0) {
+        message.success(`已删除 ${result.deleted.length} 个隐私邮箱`)
+      } else {
+        message.warning(
+          `删除 ${result.deleted.length} 个，失败 ${result.failed.length} 个：${result.failed[0].message}`,
+        )
+      }
+      setSelectedAliasIds(result.failed.map((item) => item.alias_id))
+      await load()
+    } catch (error) {
+      message.error((error as Error).message)
+    } finally {
+      setBatchDeleting(false)
+    }
+  }
+
+  const exportAliases = (mode: AliasExportMode) => {
+    if (targetAliases.length === 0) return
+    downloadTextFile(ALIAS_EXPORT_FILENAME, formatAliasExport(targetAliases, mode))
+    message.success(`已导出 ${targetAliases.length} 条`)
+  }
 
   const accountColumns = [
     {
@@ -327,12 +377,47 @@ export default function ICloudPage() {
                   >
                     生成隐私邮箱
                   </Button>
+                  <Dropdown.Button
+                    icon={<DownOutlined />}
+                    disabled={targetAliases.length === 0}
+                    onClick={() => exportAliases('self')}
+                    menu={{
+                      items: [
+                        { key: 'self', label: '隐私邮箱----隐私邮箱' },
+                        { key: 'account', label: '隐私邮箱----所属主号' },
+                      ],
+                      onClick: ({ key }) => exportAliases(key as AliasExportMode),
+                    }}
+                  >
+                    <DownloadOutlined /> 导出 ({targetAliases.length})
+                  </Dropdown.Button>
+                  {selectedAliasIds.length > 0 && (
+                    <>
+                      <Popconfirm
+                        title={`删除选中的 ${selectedAliasIds.length} 个隐私邮箱`}
+                        description="会先在 iCloud 停用并删除这些地址，删除后无法恢复。"
+                        okText="删除"
+                        cancelText="取消"
+                        okButtonProps={{ danger: true }}
+                        onConfirm={handleBatchDelete}
+                      >
+                        <Button danger icon={<DeleteOutlined />} loading={batchDeleting}>
+                          删除 {selectedAliasIds.length} 个
+                        </Button>
+                      </Popconfirm>
+                      <Text type="secondary">已选 {selectedAliasIds.length} 个</Text>
+                    </>
+                  )}
                 </Space>
                 <Table
                   rowKey="id"
                   loading={loading}
                   columns={aliasColumns}
                   dataSource={aliases}
+                  rowSelection={{
+                    selectedRowKeys: selectedAliasIds,
+                    onChange: setSelectedAliasIds,
+                  }}
                   pagination={{ pageSize: 20, showSizeChanger: false }}
                   locale={{
                     emptyText: (

--- a/services/icloud_service.py
+++ b/services/icloud_service.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import logging
 import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
@@ -27,6 +28,8 @@ from platforms.icloud import (
     normalize_region,
     web_client,
 )
+
+logger = logging.getLogger(__name__)
 
 # Apple 对每个主号限制每滚动小时最多成功生成 5 个隐私邮箱。
 HOURLY_ALIAS_LIMIT = 5
@@ -363,6 +366,34 @@ def delete_alias(alias_id: int, *, remote: bool = True, proxy: str | None = None
         if alias is not None:
             session.delete(alias)
             session.commit()
+
+
+def delete_aliases(
+    alias_ids: list[int], *, remote: bool = True, proxy: str | None = None
+) -> dict[str, Any]:
+    """批量删除隐私邮箱。
+
+    逐条走单条删除的老路，一条失败不拖累后面的：上游偶发拒绝、个别地址已经在
+    Apple 那边不存在都很常见，整批回滚只会让用户反复重试。
+    """
+    deleted: list[int] = []
+    failed: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for raw_id in alias_ids:
+        alias_id = int(raw_id)
+        if alias_id in seen:
+            continue
+        seen.add(alias_id)
+        try:
+            delete_alias(alias_id, remote=remote, proxy=proxy)
+        except ICloudError as error:
+            failed.append({"alias_id": alias_id, "code": error.code, "message": str(error)})
+        except Exception as error:  # noqa: BLE001 - 批量里不能让单条异常吞掉剩下的
+            logger.exception("批量删除隐私邮箱 %s 失败", alias_id)
+            failed.append({"alias_id": alias_id, "code": "unknown", "message": str(error)})
+        else:
+            deleted.append(alias_id)
+    return {"deleted": deleted, "failed": failed}
 
 
 def _upsert_alias(

--- a/tests/test_icloud_api.py
+++ b/tests/test_icloud_api.py
@@ -182,6 +182,88 @@ def test_apple_rejection_stays_in_4xx_so_the_reason_survives(client, monkeypatch
     assert response.json()["detail"] == "iCloud HME 拒绝了请求"
 
 
+def test_batch_delete_revokes_every_selected_alias_upstream(client):
+    account = _import_account(client)
+    created = client.post(
+        "/api/icloud/aliases", json={"account_id": account["id"], "count": 3}
+    ).json()["items"]
+    ids = [item["id"] for item in created[:2]]
+
+    response = client.post("/api/icloud/aliases/batch-delete", json={"ids": ids})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "deleted": ids, "failed": []}
+    assert client.stub.deleted == [item["address"] for item in created[:2]]
+    assert [item["id"] for item in client.get("/api/icloud/aliases").json()["items"]] == [
+        created[2]["id"]
+    ]
+
+
+def test_batch_delete_keeps_going_after_one_alias_fails(client, monkeypatch):
+    """一条删不掉不能拖累整批，否则用户只能一个个试到底是哪个卡住。"""
+    account = _import_account(client)
+    created = client.post(
+        "/api/icloud/aliases", json={"account_id": account["id"], "count": 2}
+    ).json()["items"]
+    doomed = created[0]["address"]
+
+    def _reject(_credentials, *, address, provider_id="", status=""):
+        if address == doomed:
+            raise ICloudError("upstream_rejected", "iCloud 拒绝了删除请求")
+        client.stub.deleted.append(address)
+
+    monkeypatch.setattr(client.stub, "delete_private_email", _reject)
+
+    response = client.post(
+        "/api/icloud/aliases/batch-delete",
+        json={"ids": [item["id"] for item in created]},
+    )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["ok"] is False
+    assert body["deleted"] == [created[1]["id"]]
+    assert body["failed"] == [
+        {
+            "alias_id": created[0]["id"],
+            "code": "upstream_rejected",
+            "message": "iCloud 拒绝了删除请求",
+        }
+    ]
+    # 失败那条必须还在库里，不然本地没了、Apple 那边还占着额度
+    assert [item["id"] for item in client.get("/api/icloud/aliases").json()["items"]] == [
+        created[0]["id"]
+    ]
+
+
+def test_batch_delete_can_skip_the_upstream_call(client):
+    account = _import_account(client)
+    alias = client.post("/api/icloud/aliases", json={"account_id": account["id"]}).json()["items"][0]
+
+    response = client.post(
+        "/api/icloud/aliases/batch-delete", json={"ids": [alias["id"]], "remote": False}
+    )
+
+    assert response.status_code == 200
+    assert client.stub.deleted == []
+    assert client.get("/api/icloud/aliases").json()["items"] == []
+
+
+def test_batch_delete_reports_unknown_ids_instead_of_silently_passing(client):
+    response = client.post("/api/icloud/aliases/batch-delete", json={"ids": [999, 999]})
+
+    body = response.json()
+    assert body["ok"] is False
+    assert body["deleted"] == []
+    # 同一个 id 重复提交只算一次
+    assert [item["alias_id"] for item in body["failed"]] == [999]
+    assert body["failed"][0]["code"] == "alias_not_found"
+
+
+def test_batch_delete_without_ids_is_a_400(client):
+    assert client.post("/api/icloud/aliases/batch-delete", json={"ids": []}).status_code == 400
+
+
 def test_unknown_account_and_alias_map_to_http_404(client):
     assert client.post("/api/icloud/accounts/999/sync").status_code == 404
     assert client.request("DELETE", "/api/icloud/aliases/999").status_code == 404


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
隐私邮箱列表支持批量选择、批量删除与导出。

## 导出

- 默认格式：`隐私邮箱----隐私邮箱`（每行一条，分隔符为四个短横线）
- 可选：`隐私邮箱----所属主号`
- 未勾选时导出当前筛选结果；勾选后只导选中项

## 批量删除

- 新增 `POST /icloud/aliases/batch-delete`，内部逐条复用现有删除逻辑（先上游停用再删本地）
- 单条失败不中断整批，失败项保留并可重试
- 删除前有确认提示

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35260470-e43e-4abe-a670-08823bc564b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35260470-e43e-4abe-a670-08823bc564b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

