### PR TITLE
fix: 失败重试轮数在手机注册上真正生效

### DIFF
--- a/api/tasks.py
+++ b/api/tasks.py
@@ -31,6 +31,13 @@ _task_store = RegisterTaskStore(
 
 MAX_REGISTER_RETRY_TIMES = 10
 DEFAULT_REGISTER_RETRY_TIMES = 1
+# 「重开也是同样结局」的失败最多连着出现几轮就收手。
+#
+# 手机注册里这类失败（账号已建好、接码平台一条短信都没收到）以前是一票否决：
+# 第一轮撞上就把用户填的重试轮数整个作废，看上去就是「我写了没反应」。可一轮
+# 只用了一个号，凭它断定整个号源都被静默拦码证据太薄 —— 再开一轮确认一下，
+# 连着两轮同样结局才是真的号源问题，那时候继续只会多几个孤号。
+MAX_DEAD_END_ROUNDS = 2
 
 
 def normalize_register_retry_times(value) -> int:
@@ -496,7 +503,17 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
                 proxy=proxy,
             )
 
-        total_rounds = 1 + normalize_register_retry_times(req.register_retry_times)
+        retry_times = normalize_register_retry_times(req.register_retry_times)
+        total_rounds = 1 + retry_times
+        if total_rounds > 1:
+            _log(
+                task_id,
+                f"失败重试轮数 {retry_times}：每个账号失败后最多重开 {retry_times} 轮，"
+                f"连同首轮共 {total_rounds} 轮（每轮都是全新的代理/邮箱/号码/会话）",
+            )
+
+        def _is_dead_end(result: AttemptResult) -> bool:
+            return result.outcome == AttemptOutcome.FAILED and not result.retryable
 
         def _do_one(i: int):
             """一个序号的完整交付：失败就整流程重开一轮，直到轮次用尽。
@@ -505,25 +522,37 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
             半路建出来的号已经被占了，拿它死磕只会一直撞同一堵墙。
             """
             result = _do_one_round(i, 1, total_rounds)
+            dead_end_rounds = 1 if _is_dead_end(result) else 0
             for round_no in range(2, total_rounds + 1):
                 if result.outcome != AttemptOutcome.FAILED:
-                    return result
+                    break
                 if control.is_stop_requested():
-                    return result
-                if not result.retryable:
-                    # 号源被静默拦下这类失败，重开一轮只是再租一次号、再造一个孤号
+                    break
+                if dead_end_rounds >= MAX_DEAD_END_ROUNDS:
                     _log(
                         task_id,
-                        f"[RETRY] 第 {i + 1} 个账号这次的失败重开也是同样结局，"
-                        f"跳过剩下 {total_rounds - round_no + 1} 轮: {result.message}",
+                        f"[RETRY] 第 {i + 1} 个账号连续 {dead_end_rounds} 轮都栽在"
+                        f"「重开也是同样结局」的失败上，剩下 "
+                        f"{total_rounds - round_no + 1} 轮不再重开"
+                        f"（再开只会多几个没人认领的号）: {result.message}",
                     )
-                    return result
+                    break
                 _log(
                     task_id,
                     f"[RETRY] 第 {i + 1} 个账号第 {round_no - 1}/{total_rounds} 轮失败，"
-                    f"重开第 {round_no}/{total_rounds} 轮（全新会话）: {result.message}",
+                    f"开始第 {round_no}/{total_rounds} 轮重试（全新会话）: {result.message}",
                 )
                 result = _do_one_round(i, round_no, total_rounds)
+                dead_end_rounds = dead_end_rounds + 1 if _is_dead_end(result) else 0
+            if result.outcome == AttemptOutcome.FAILED:
+                # 注册记录按"一个序号一条结果"记，所以只有跑完所有轮次才落一条
+                # failed；否则重试成功了还会在统计里留下一条失败
+                _save_task_log(
+                    req.platform,
+                    result.email,
+                    "failed",
+                    error=result.message,
+                )
             return result
 
         def _do_one_round(i: int, round_no: int, rounds: int):
@@ -531,7 +560,6 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
             _proxy = None
             current_email = req.email or ""
             attempt_id: int | None = None
-            is_last_round = round_no >= rounds
             round_suffix = f"（第 {round_no}/{rounds} 轮）" if rounds > 1 else ""
             try:
                 control.checkpoint()
@@ -654,17 +682,11 @@ def _run_register(task_id: str, req: RegisterTaskRequest):
                 if _proxy:
                     _proxy_pool.report_fail(_proxy)
                 _log(task_id, f"[FAIL] 注册失败{round_suffix}: {e}")
-                retryable = not isinstance(e, NonRetryableRegisterError)
-                # 中间轮次的失败只写任务日志：注册记录按"一个序号一条结果"记，
-                # 否则重试成功了还会在统计里留下一条失败
-                if is_last_round or not retryable:
-                    _save_task_log(
-                        req.platform,
-                        current_email,
-                        "failed",
-                        error=str(e),
-                    )
-                return AttemptResult.failed(str(e), retryable=retryable)
+                return AttemptResult.failed(
+                    str(e),
+                    retryable=not isinstance(e, NonRetryableRegisterError),
+                    email=current_email,
+                )
             finally:
                 control.finish_attempt(attempt_id)
 

--- a/core/task_runtime.py
+++ b/core/task_runtime.py
@@ -48,14 +48,19 @@ class AttemptResult:
     message: str = ""
     # 有些失败重开一轮也是同样的结局，还要再赔上一次租号和一个半成品账号
     retryable: bool = True
+    # 这一轮用的身份（邮箱或手机号）。多轮重试时只有最终结果才落注册记录，
+    # 所以身份要跟着结果一起交回去。
+    email: str = ""
 
     @classmethod
     def success(cls) -> "AttemptResult":
         return cls(AttemptOutcome.SUCCESS)
 
     @classmethod
-    def failed(cls, message: str, *, retryable: bool = True) -> "AttemptResult":
-        return cls(AttemptOutcome.FAILED, message, retryable=retryable)
+    def failed(
+        cls, message: str, *, retryable: bool = True, email: str = ""
+    ) -> "AttemptResult":
+        return cls(AttemptOutcome.FAILED, message, retryable=retryable, email=email)
 
     @classmethod
     def skipped(cls, message: str) -> "AttemptResult":

--- a/frontend/src/pages/Accounts.tsx
+++ b/frontend/src/pages/Accounts.tsx
@@ -1626,7 +1626,7 @@ export default function Accounts() {
               name="register_retry_times"
               label="失败重试轮数"
               initialValue={DEFAULT_REGISTER_RETRY_TIMES}
-              tooltip="整条注册流程失败后自动重开一轮：换新邮箱 / 新号码 / 新会话。0 表示失败即止。"
+              tooltip="整条注册流程失败后自动重开一轮：换新邮箱 / 新号码 / 新会话。0 表示失败即止。手机注册连续两轮都「建出了号却一条短信都没收到」时会提前收手，不再多造孤号。"
             >
               <InputNumber min={0} max={10} precision={0} style={{ width: '100%' }} placeholder="1" />
             </Form.Item>

--- a/frontend/src/pages/RegisterTaskPage.tsx
+++ b/frontend/src/pages/RegisterTaskPage.tsx
@@ -316,7 +316,7 @@ export default function RegisterTaskPage() {
             <Form.Item
               name="register_retry_times"
               label="失败重试轮数"
-              tooltip="整条注册流程失败后自动重开一轮：换新邮箱 / 新号码 / 新会话。0 表示失败即止；和接码里的「最多换号」不是一回事。"
+              tooltip="整条注册流程失败后自动重开一轮：换新邮箱 / 新号码 / 新会话。0 表示失败即止；和接码里的「最多换号」不是一回事。手机注册连续两轮都「建出了号却一条短信都没收到」时会提前收手，不再多造孤号。"
               style={{ flex: 1 }}
             >
               <InputNumber min={0} max={10} precision={0} style={{ width: '100%' }} placeholder="1" />

--- a/platforms/chatgpt/protocol/phone_flow.py
+++ b/platforms/chatgpt/protocol/phone_flow.py
@@ -91,6 +91,10 @@ def is_flow_state_error(text: str) -> bool:
 class PhoneRegisterMixin:
     """手机号注册 + 绑定邮箱。混进 ``AuthFlow``，共用同一个 session 和结果对象。"""
 
+    # 这一轮里接码平台有没有吐出过验证码。零短信是判定"号源被静默拦下"的唯一
+    # 硬证据，外层要靠它决定还值不值得再开一轮。
+    _phone_sms_ever_received = False
+
     # ── 状态判定 ──
 
     @staticmethod
@@ -520,6 +524,7 @@ class PhoneRegisterMixin:
         last_err: Optional[Exception] = None
         repeated_err = ""
         repeated_count = 0
+        self._phone_sms_ever_received = False
 
         for attempt in range(1, max_phone_attempts + 1):
             logger.info("[手机注册] 🔁 第 %d/%d 个号尝试...", attempt, max_phone_attempts)
@@ -690,7 +695,10 @@ class PhoneRegisterMixin:
         except Exception as exc:
             cause = getattr(exc, "cause", exc)
             raise PhoneAccountCreatedError(
-                str(cause), phone=phone, password=self.result.password
+                str(cause),
+                phone=phone,
+                password=self.result.password,
+                sms_ever_received=self._phone_sms_ever_received,
             ) from cause
 
     def _continue_after_phone_verified(
@@ -788,6 +796,7 @@ class PhoneRegisterMixin:
             code = ctrl.get_code(timeout=int(remaining))
             if not code:
                 break
+            self._phone_sms_ever_received = True
             if code in seen_codes:
                 logger.warning("[手机注册] 收到重复验证码 %s，跳过", code)
                 continue
@@ -890,14 +899,24 @@ class PhoneAccountCreatedError(RuntimeError):
     此为止。报错里带上手机号和密码：这两样是把号找回来的唯一线索。
     """
 
-    def __init__(self, reason: str, *, phone: str, password: str = ""):
+    def __init__(
+        self,
+        reason: str,
+        *,
+        phone: str,
+        password: str = "",
+        sms_ever_received: Optional[bool] = None,
+    ):
         self.phone = phone
         self.password = password
         self.reason = reason
         # 发码请求被受理、接码平台却一条短信都没收到 —— 这是号源被静默拦下，
-        # 不是这一次运气差。整条流程重开只会用同样的号源再造一个孤号，所以
-        # 明确标成"别重试"，让外层把剩下的轮次省下来。
-        self.sms_never_arrived = "没收到短信" in reason or "超时" in reason
+        # 不是这一次运气差，所以标成"重开也是同样结局"让外层少赔几轮。
+        #
+        # 判据只有一个：这一轮从头到尾有没有从接码平台拿到过验证码。以前是拿
+        # 错误文本猜的，"超时"两个字太宽 —— 换 RT 超时、网络超时都会被误判成
+        # 号源问题，用户填的重试轮数就这么被无声地作废了。
+        self.sms_never_arrived = "没收到短信" in reason and sms_ever_received is not True
         self.retryable = not self.sms_never_arrived
         detail = f"手机号 {phone} 的账号已在 OpenAI 侧创建"
         if password:

--- a/tests/test_chatgpt_phone_register.py
+++ b/tests/test_chatgpt_phone_register.py
@@ -636,10 +636,31 @@ class PhoneRegisterLoopTests(unittest.TestCase):
         }
         flow.phone_register_user = lambda phone: {"page": {"type": "phone_otp_verification"}}
 
-        with self.assertRaises(PhoneAccountCreatedError):
+        with self.assertRaises(PhoneAccountCreatedError) as ctx:
             flow._do_phone_register_loop(ctrl)
 
         self.assertEqual(len(ctrl.rented), 1)
+        # 一条短信都没进来：这才是"号源被静默拦下"该有的证据
+        self.assertFalse(ctx.exception.retryable)
+
+    def test_a_code_that_did_arrive_keeps_the_round_retryable(self):
+        """码进来了、后面才崩 —— 号源是活的，外层重开一轮有真机会。"""
+        ctrl = _FakeController(max_attempts=3)
+        flow = _loop_flow()
+        flow.phone_authorize_continue = lambda phone, sentinel: {
+            "page": {"type": "create_account_password"}
+        }
+        flow.phone_register_user = lambda phone: {"page": {"type": "phone_otp_verification"}}
+
+        def _validate(code, referer=""):
+            raise RuntimeError("phone-otp/validate 超时")
+
+        flow._phone_otp_validate = _validate
+
+        with self.assertRaises(PhoneAccountCreatedError) as ctx:
+            flow._do_phone_register_loop(ctrl)
+
+        self.assertTrue(ctx.exception.retryable)
 
 
 class PhoneAccountCreatedMessageTests(unittest.TestCase):
@@ -661,6 +682,23 @@ class PhoneAccountCreatedMessageTests(unittest.TestCase):
             "phone-otp/validate 返回 400", phone="+66968649749", password="pw"
         )
         self.assertTrue(err.retryable)
+
+    def test_an_unrelated_timeout_is_not_a_dead_end(self):
+        """以前"超时"两个字就够判死一整轮，换 RT 慢一点都会连累用户填的重试轮数。"""
+        err = PhoneAccountCreatedError(
+            "Codex 换 refresh_token 超时", phone="+66968649749", password="pw"
+        )
+        self.assertTrue(err.retryable)
+
+    def test_a_code_that_arrived_earlier_outweighs_a_later_timeout(self):
+        err = PhoneAccountCreatedError(
+            "号 +66968649749 在 150s 内没收到短信",
+            phone="+66968649749",
+            password="pw",
+            sms_ever_received=True,
+        )
+        self.assertTrue(err.retryable)
+        self.assertNotIn("接码平台全程没收到任何短信", str(err))
 
 
 class SendPhoneOtpTests(unittest.TestCase):

--- a/tests/test_register_task_controls.py
+++ b/tests/test_register_task_controls.py
@@ -125,11 +125,12 @@ class _FlakyPlatform(BasePlatform):
 class RegisterRetryRoundsTests(unittest.TestCase):
     """整流程重试：一次失败不该直接把这个序号判死。"""
 
-    def _run(self, task_id: str, *, fail_times: int, retry_times: int):
+    def _run(self, task_id: str, *, fail_times: int, retry_times: int, email: str = None):
         req = RegisterTaskRequest(
             platform="chatgpt",
             count=1,
             concurrency=1,
+            email=email,
             register_retry_times=retry_times,
             extra={"mail_provider": "fake"},
         )
@@ -157,7 +158,7 @@ class RegisterRetryRoundsTests(unittest.TestCase):
         self.assertEqual(snapshot["success"], 1)
         self.assertEqual(snapshot["errors"], [])
         self.assertEqual(_FlakyPlatform.attempts, 2)
-        self.assertIn("重开第 2/2 轮", joined)
+        self.assertIn("开始第 2/2 轮重试", joined)
         self.assertIn("开始注册第 1/1 个账号（第 2/2 轮）", joined)
         # 中途失败不该在注册记录里留下一条 failed，否则统计会双记
         self.assertEqual([args[2] for args, _ in saved_logs], ["success"])
@@ -170,6 +171,17 @@ class RegisterRetryRoundsTests(unittest.TestCase):
         self.assertEqual(_FlakyPlatform.attempts, 3)
         self.assertEqual([args[2] for args, _ in saved_logs], ["failed"])
 
+    def test_the_recorded_failure_keeps_the_identity_of_the_last_round(self):
+        """收尾那条 failed 记录得带上身份，否则任务历史里只剩一行没有主语的报错。"""
+        _snapshot, saved_logs = self._run(
+            "task-retry-identity",
+            fail_times=5,
+            retry_times=1,
+            email="fixed@example.com",
+        )
+
+        self.assertEqual([args[1] for args, _ in saved_logs], ["fixed@example.com"])
+
     def test_zero_retries_keeps_the_old_single_round_behaviour(self):
         snapshot, _saved = self._run("task-retry-disabled", fail_times=5, retry_times=0)
         joined = "\n".join(snapshot["logs"])
@@ -179,6 +191,15 @@ class RegisterRetryRoundsTests(unittest.TestCase):
         self.assertNotIn("[RETRY]", joined)
         # 只有一轮时日志不该多出"第 x/y 轮"的噪声
         self.assertIn("开始注册第 1/1 个账号\n", joined + "\n")
+        self.assertNotIn("失败重试轮数", joined)
+
+    def test_the_configured_rounds_are_announced_up_front(self):
+        """填了轮数就得在日志里看得见，否则用户只能猜这个框有没有生效。"""
+        snapshot, _saved = self._run("task-retry-announced", fail_times=0, retry_times=3)
+        joined = "\n".join(snapshot["logs"])
+
+        self.assertIn("失败重试轮数 3", joined)
+        self.assertIn("共 4 轮", joined)
 
 
 class _DeadEndPlatform(_FlakyPlatform):
@@ -191,23 +212,39 @@ class _DeadEndPlatform(_FlakyPlatform):
         raise NonRetryableRegisterError("手机号 +2349157587437 的账号已在 OpenAI 侧创建")
 
 
-class NonRetryableFailureTests(unittest.TestCase):
-    """号源被静默拦下时，多开几轮只会多几个孤号。"""
+class _DeadEndThenFinePlatform(_FlakyPlatform):
+    """第一轮撞上"重开也没用"，第二轮正常注册出账号。"""
 
-    def test_dead_end_failure_skips_the_remaining_rounds(self):
+    attempts = 0
+
+    def register(self, email: str, password: str = None) -> Account:
+        type(self).attempts += 1
+        if type(self).attempts == 1:
+            raise NonRetryableRegisterError("手机号 +2349157587437 的账号已在 OpenAI 侧创建")
+        return Account(
+            platform="chatgpt",
+            email="rescued@example.com",
+            password=password or "pw",
+        )
+
+
+class NonRetryableFailureTests(unittest.TestCase):
+    """号源被静默拦下时多开几轮只会多几个孤号 —— 但一轮的证据太薄。"""
+
+    def _run(self, task_id: str, platform_cls, *, retry_times: int):
         req = RegisterTaskRequest(
             platform="chatgpt",
             count=1,
             concurrency=1,
-            register_retry_times=4,
+            register_retry_times=retry_times,
             extra={"mail_provider": "fake"},
         )
-        _create_task_record("task-retry-dead-end", req, "manual", None)
-        _DeadEndPlatform.attempts = 0
+        _create_task_record(task_id, req, "manual", None)
+        platform_cls.attempts = 0
         saved_logs: list[tuple] = []
 
         with (
-            patch("core.registry.get", return_value=_DeadEndPlatform),
+            patch("core.registry.get", return_value=platform_cls),
             patch("core.base_mailbox.create_mailbox", return_value=_FakeMailbox()),
             patch("core.db.save_account", side_effect=lambda account: account),
             patch(
@@ -215,16 +252,42 @@ class NonRetryableFailureTests(unittest.TestCase):
                 side_effect=lambda *args, **kwargs: saved_logs.append((args, kwargs)),
             ),
         ):
-            _run_register("task-retry-dead-end", req)
+            _run_register(task_id, req)
 
-        snapshot = _task_store.snapshot("task-retry-dead-end")
+        return _task_store.snapshot(task_id), saved_logs
+
+    def test_dead_end_still_gets_one_confirming_round(self):
+        """一轮零短信不足以判死整个号源，用户填的轮数至少得动起来。"""
+        snapshot, saved_logs = self._run(
+            "task-retry-dead-end", _DeadEndPlatform, retry_times=4
+        )
         joined = "\n".join(snapshot["logs"])
 
-        self.assertEqual(_DeadEndPlatform.attempts, 1)
-        self.assertIn("跳过剩下 4 轮", joined)
+        self.assertEqual(_DeadEndPlatform.attempts, 2)
+        self.assertIn("开始第 2/5 轮重试", joined)
+        self.assertIn("连续 2 轮", joined)
+        self.assertIn("剩下 3 轮不再重开", joined)
         self.assertEqual(len(snapshot["errors"]), 1)
         # 提前收手也要落一条 failed 记录，否则这个序号在统计里凭空消失
         self.assertEqual([args[2] for args, _ in saved_logs], ["failed"])
+
+    def test_the_confirming_round_can_still_succeed(self):
+        snapshot, saved_logs = self._run(
+            "task-retry-dead-end-rescued", _DeadEndThenFinePlatform, retry_times=4
+        )
+
+        self.assertEqual(_DeadEndThenFinePlatform.attempts, 2)
+        self.assertEqual(snapshot["success"], 1)
+        self.assertEqual(snapshot["errors"], [])
+        self.assertEqual([args[2] for args, _ in saved_logs], ["success"])
+
+    def test_zero_retries_still_means_a_single_round(self):
+        snapshot, _saved = self._run(
+            "task-retry-dead-end-no-budget", _DeadEndPlatform, retry_times=0
+        )
+
+        self.assertEqual(_DeadEndPlatform.attempts, 1)
+        self.assertEqual(len(snapshot["errors"]), 1)
 
 
 class RegisterRetryTimesNormalisationTests(unittest.TestCase):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
修复「失败重试轮数」在手机注册上形同虚设的问题：
- 原先「没收到短信 / 超时」一律 `NonRetryable`，一轮就吃掉全部预算
- 改为按是否真正拿到过短信判断死胡同；死胡同最多确认 2 轮后停，其余失败吃满用户配置的轮数
- 日志明确打出「第 x/N 轮重试」与提前停止原因

## Test plan
- [x] pytest（含重试预算相关新用例）
- [ ] 手机注册把重试轮数设为 ≥2，故意等不到码，确认日志出现第 2 轮

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35260470-e43e-4abe-a670-08823bc564b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35260470-e43e-4abe-a670-08823bc564b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

