### PR TITLE
fix: MailAPI URL 导入保持 + 隐私邮箱导出邮件 URL

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,7 +1,13 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 from core.config_store import config_store
-from services.mail_imports import MailImportExecuteRequest, MailImportSnapshotRequest, mail_import_registry
+from services.mail_imports import (
+    MailImportExecuteRequest,
+    MailImportSnapshotRequest,
+    align_source_with_provider,
+    mail_import_registry,
+    normalize_mail_import_source,
+)
 from services.sms_service import SMS_DEFAULT_COUNTRY, SMS_DEFAULT_SERVICE
 
 router = APIRouter(prefix="/config", tags=["config"])
@@ -39,6 +45,7 @@ CONFIG_KEYS = [
     "cloudmail_subdomain",
     "cloudmail_timeout",
     "mail_provider",
+    "mail_import_source",
     "outlook_backend",
     "mailbox_otp_timeout_seconds",
     "maliapi_base_url",
@@ -136,6 +143,10 @@ def get_config():
         all_cfg["mail_provider"] = "microsoft"
     if not all_cfg.get("mail_provider"):
         all_cfg["mail_provider"] = "luckmail"
+    all_cfg["mail_import_source"] = normalize_mail_import_source(
+        all_cfg.get("mail_import_source"),
+        all_cfg.get("mail_provider"),
+    )
     if not all_cfg.get("applemail_base_url"):
         all_cfg["applemail_base_url"] = "https://www.appleemail.top"
     if not all_cfg.get("applemail_pool_dir"):
@@ -180,6 +191,14 @@ def update_config(body: ConfigUpdate):
     safe = {k: v for k, v in body.data.items() if k in CONFIG_KEYS}
     if safe.get("mail_provider") == "outlook":
         safe["mail_provider"] = "microsoft"
+    if "mail_import_source" in safe:
+        # 只有同一次请求里带了 mail_provider 才谈得上对齐；面板单独改视图时，
+        # 视图本身就是用户的新选择，不该被库里的旧 provider 拽回去
+        safe["mail_import_source"] = (
+            align_source_with_provider(safe["mail_import_source"], safe["mail_provider"])
+            if "mail_provider" in safe
+            else normalize_mail_import_source(safe["mail_import_source"])
+        )
     if "email_domain_rule_enabled" in safe:
         enabled = str(safe.get("email_domain_rule_enabled", "")).strip().lower()
         safe["email_domain_rule_enabled"] = (

--- a/core/base_mailbox.py
+++ b/core/base_mailbox.py
@@ -3490,8 +3490,11 @@ class MailApiUrlOtpBackend(OutlookMailboxBackend):
         return str(response.text or "")
 
     def _extract_code(self, text: str, code_pattern: str | None) -> str:
-        normalized_text = self.mailbox._decode_raw_content(text) or str(text or "")
-        return str(self.mailbox._safe_extract(normalized_text, code_pattern) or "").strip()
+        # MailAPI 返回的是网页/JSON，不是原始邮件：按邮件头切分会从第一个空行处
+        # 把正文腰斩（分享页的 <style> 里就有空行），码常常正好落在被砍掉的那半边。
+        # 提取也走剥链接的那版，免得把 SendGrid 追踪链接里的数字当成验证码。
+        normalized_text = self.mailbox._yyds_decode_raw_content(text) or str(text or "")
+        return str(self.mailbox._yyds_safe_extract(normalized_text, code_pattern) or "").strip()
 
     def get_current_ids(self, account: MailboxAccount) -> set:
         try:

--- a/frontend/src/components/settings/MailImportPanel.tsx
+++ b/frontend/src/components/settings/MailImportPanel.tsx
@@ -2,11 +2,11 @@ import { useEffect, useMemo, useState } from 'react'
 import { App, Alert, Button, Card, Form, Input, InputNumber, Popconfirm, Select, Space, Switch, Table, Tag, Typography } from 'antd'
 import type { FormInstance } from 'antd'
 
+import { normalizeMailImportSource, type MailImportSource } from '@/lib/mailImport'
 import { apiFetch } from '@/lib/utils'
 
 type MailImportProviderType = 'applemail' | 'microsoft'
-type MailImportSelectionType = MailImportProviderType | 'outlook' | 'hotmail' | 'mailapi'
-type MailImportFormProviderType = MailImportProviderType | 'mail_import'
+type MailImportSelectionType = MailImportSource
 
 interface MailImportPanelProps {
   form: FormInstance
@@ -64,24 +64,23 @@ interface MailImportResult {
 }
 
 const SUPPORTED_IMPORT_TYPES: MailImportProviderType[] = ['applemail', 'microsoft']
-const SUPPORTED_SELECTION_TYPES: MailImportSelectionType[] = ['applemail', 'microsoft', 'outlook', 'hotmail', 'mailapi']
 
 function isSupportedImportType(value: string): value is MailImportProviderType {
   return SUPPORTED_IMPORT_TYPES.includes(value as MailImportProviderType)
-}
-
-function isSupportedSelectionType(value: string): value is MailImportSelectionType {
-  return SUPPORTED_SELECTION_TYPES.includes(value as MailImportSelectionType)
 }
 
 function toImportApiType(value: MailImportSelectionType): MailImportProviderType {
   return value === 'applemail' ? 'applemail' : 'microsoft'
 }
 
-function resolveMicrosoftImportType(domain: string) {
+function resolveMicrosoftImportType(domain: string): MailImportSelectionType {
   return domain.includes('hotmail') ? 'hotmail' : 'outlook'
 }
 
+/**
+ * 选中哪一栏由已保存的 `mail_import_source` 说了算。以前这里按 mail_provider +
+ * luckmail 域名反推，反推不出 MailAPI URL，于是每次重新挂载都把选择拽回 Outlook。
+ */
 function resolvePreferredImportType(
   currentMailProvider: string,
   mailImportSource: string,
@@ -89,11 +88,12 @@ function resolvePreferredImportType(
   luckmailDomain: string,
   applemailPoolFile: string,
 ): MailImportSelectionType {
-  if (currentMailProvider === 'mail_import') {
-    return mailImportSource === 'applemail' ? 'applemail' : resolveMicrosoftImportType(String(luckmailDomain || '').trim().toLowerCase())
+  const savedSource = String(mailImportSource || '').trim().toLowerCase()
+  if (savedSource) {
+    return normalizeMailImportSource(savedSource, currentMailProvider)
   }
   if (currentMailProvider === 'applemail') return 'applemail'
-  if (currentMailProvider === 'microsoft' || currentMailProvider === 'outlook') {
+  if (currentMailProvider === 'mail_import' || currentMailProvider === 'microsoft' || currentMailProvider === 'outlook') {
     return resolveMicrosoftImportType(String(luckmailDomain || '').trim().toLowerCase())
   }
 
@@ -210,8 +210,8 @@ function buildResultMessage(result: MailImportResult) {
 
 export default function MailImportPanel({ form }: MailImportPanelProps) {
   const { message } = App.useApp()
-  const currentMailProvider = String(Form.useWatch('mail_provider', form) || '') as MailImportFormProviderType
-  const currentMailImportSource = String(Form.useWatch('mail_import_source', form) || 'microsoft')
+  const currentMailProvider = String(Form.useWatch('mail_provider', form) || '')
+  const currentMailImportSource = String(Form.useWatch('mail_import_source', form) || '')
   const watchedPoolDir = String(Form.useWatch('applemail_pool_dir', form) || 'mail')
   const watchedPoolFile = String(Form.useWatch('applemail_pool_file', form) || '')
   const watchedLuckmailEmailType = String(Form.useWatch('luckmail_email_type', form) || '')
@@ -262,6 +262,21 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
     [snapshot],
   )
 
+  /**
+   * 视图选择立刻落库，不等整页「保存」。用户在这里选完 MailAPI URL 就去别的页面
+   * 是常态，只留在表单里等于没选。失败了也不打扰——表单里那份还在。
+   */
+  const persistImportSource = async (value: MailImportSelectionType) => {
+    try {
+      await apiFetch('/config', {
+        method: 'PUT',
+        body: JSON.stringify({ data: { mail_import_source: value } }),
+      })
+    } catch {
+      // 忽略：下次点保存会把整份配置一起写回去
+    }
+  }
+
   const loadProviders = async () => {
     setLoadingProviders(true)
     try {
@@ -270,7 +285,7 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
       const displayProviders = buildDisplayProviders(items)
       setProviders(displayProviders)
 
-      if (isSupportedSelectionType(preferredImportType) && displayProviders.some((item) => item.type === preferredImportType)) {
+      if (displayProviders.some((item) => item.type === preferredImportType)) {
         setSelectedType(preferredImportType)
       } else if (displayProviders.length > 0) {
         setSelectedType(displayProviders[0].type)
@@ -367,11 +382,13 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
           applemail_pool_dir: response.snapshot.pool_dir,
           applemail_pool_file: response.snapshot.filename,
         })
+        void persistImportSource('applemail')
       } else if (response.type === 'microsoft') {
         form.setFieldsValue({
           mail_provider: 'mail_import',
-          mail_import_source: 'microsoft',
+          mail_import_source: selectedType,
         })
+        void persistImportSource(selectedType)
       }
 
       message.success(buildImportSuccessMessage(response))
@@ -387,8 +404,9 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
     setSelectedType(value)
     form.setFieldsValue({
       mail_provider: 'mail_import',
-      mail_import_source: value === 'applemail' ? 'applemail' : 'microsoft',
+      mail_import_source: value,
     })
+    void persistImportSource(value)
   }
 
   const handleDelete = async (item: MailImportSnapshotItem) => {

--- a/frontend/src/components/settings/MailImportPanel.tsx
+++ b/frontend/src/components/settings/MailImportPanel.tsx
@@ -73,46 +73,16 @@ function toImportApiType(value: MailImportSelectionType): MailImportProviderType
   return value === 'applemail' ? 'applemail' : 'microsoft'
 }
 
-function resolveMicrosoftImportType(domain: string): MailImportSelectionType {
-  return domain.includes('hotmail') ? 'hotmail' : 'outlook'
-}
-
 /**
- * 选中哪一栏由已保存的 `mail_import_source` 说了算。以前这里按 mail_provider +
- * luckmail 域名反推，反推不出 MailAPI URL，于是每次重新挂载都把选择拽回 Outlook。
+ * 选中哪一栏只看已保存的 `mail_import_source`。以前这里按 mail_provider 加
+ * luckmail 域名反推，反推路径里没有 MailAPI URL 这个分支，于是选完再回来必然
+ * 变回 Outlook。
  */
 function resolvePreferredImportType(
   currentMailProvider: string,
   mailImportSource: string,
-  luckmailEmailType: string,
-  luckmailDomain: string,
-  applemailPoolFile: string,
 ): MailImportSelectionType {
-  const savedSource = String(mailImportSource || '').trim().toLowerCase()
-  if (savedSource) {
-    return normalizeMailImportSource(savedSource, currentMailProvider)
-  }
-  if (currentMailProvider === 'applemail') return 'applemail'
-  if (currentMailProvider === 'mail_import' || currentMailProvider === 'microsoft' || currentMailProvider === 'outlook') {
-    return resolveMicrosoftImportType(String(luckmailDomain || '').trim().toLowerCase())
-  }
-
-  const normalizedLuckmailType = String(luckmailEmailType || '').trim().toLowerCase()
-  const normalizedLuckmailDomain = String(luckmailDomain || '').trim().toLowerCase()
-  const isMicrosoftMailbox =
-    normalizedLuckmailType.startsWith('ms_')
-    || normalizedLuckmailDomain.includes('outlook')
-    || normalizedLuckmailDomain.includes('hotmail')
-
-  if (isMicrosoftMailbox) {
-    return resolveMicrosoftImportType(normalizedLuckmailDomain)
-  }
-
-  if (String(applemailPoolFile || '').trim()) {
-    return 'applemail'
-  }
-
-  return 'outlook'
+  return normalizeMailImportSource(mailImportSource, currentMailProvider)
 }
 
 function buildDisplayProviders(providers: MailImportProviderDescriptor[]) {
@@ -214,8 +184,6 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
   const currentMailImportSource = String(Form.useWatch('mail_import_source', form) || '')
   const watchedPoolDir = String(Form.useWatch('applemail_pool_dir', form) || 'mail')
   const watchedPoolFile = String(Form.useWatch('applemail_pool_file', form) || '')
-  const watchedLuckmailEmailType = String(Form.useWatch('luckmail_email_type', form) || '')
-  const watchedLuckmailDomain = String(Form.useWatch('luckmail_domain', form) || '')
 
   const [providers, setProviders] = useState<MailImportDisplayProvider[]>([])
   const [selectedType, setSelectedType] = useState<MailImportSelectionType>('outlook')
@@ -241,14 +209,8 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
   const selectedApiType = selectedProvider?.apiType ?? toImportApiType(selectedType)
   const supportsAliasSplit = selectedApiType === 'microsoft'
   const preferredImportType = useMemo(
-    () => resolvePreferredImportType(
-      currentMailProvider,
-      currentMailImportSource,
-      watchedLuckmailEmailType,
-      watchedLuckmailDomain,
-      watchedPoolFile,
-    ),
-    [currentMailImportSource, currentMailProvider, watchedLuckmailDomain, watchedLuckmailEmailType, watchedPoolFile],
+    () => resolvePreferredImportType(currentMailProvider, currentMailImportSource),
+    [currentMailImportSource, currentMailProvider],
   )
   const snapshot = useMemo(
     () => filterSnapshotBySelection(rawSnapshot, selectedType),

--- a/frontend/src/lib/icloud.ts
+++ b/frontend/src/lib/icloud.ts
@@ -17,20 +17,46 @@ export function getICloudRegionLabel(region?: string): string {
 
 /**
  * 导出格式沿用仓库里邮箱池导入那套 `----` 分隔：
- *   self    → 隐私邮箱----隐私邮箱（默认，粘到只认「邮箱----邮箱地址」的地方）
- *   account → 隐私邮箱----所属主号（想知道每个别名挂在哪个 Apple ID 下时用）
+ *   mail_url → 隐私邮箱----邮件 URL（默认，正好是邮箱导入里 `邮箱----mailapi_url` 那一行）
+ *   account  → 隐私邮箱----所属主号（想知道每个别名挂在哪个 Apple ID 下时用）
  */
-export type AliasExportMode = 'self' | 'account'
+export type AliasExportMode = 'mail_url' | 'account'
 
 export const ALIAS_EXPORT_FILENAME = 'icloud_aliases.txt'
 
+export interface AliasExportRecord {
+  address: string
+  account_email: string
+  share_token?: string
+}
+
+/**
+ * 补 share_token 之前建的老别名没有免登录链接，这种行导不出 URL，只能整行跳过：
+ * 写一行末尾空着的 `邮箱----` 反而会让对面的导入器报格式错。
+ */
 export function formatAliasExport(
-  aliases: { address: string; account_email: string }[],
-  mode: AliasExportMode = 'self',
+  aliases: AliasExportRecord[],
+  mode: AliasExportMode = 'mail_url',
 ): string {
-  return aliases
-    .map((alias) => `${alias.address}----${mode === 'account' ? alias.account_email : alias.address}`)
-    .join('\n')
+  const lines: string[] = []
+  for (const alias of aliases) {
+    if (mode === 'account') {
+      lines.push(`${alias.address}----${alias.account_email}`)
+      continue
+    }
+    const url = aliasMailUrl(String(alias.share_token || ''))
+    if (url) lines.push(`${alias.address}----${url}`)
+  }
+  return lines.join('\n')
+}
+
+/** 导出前先算能导出几条，好在没有链接的别名被跳过时如实告诉用户。 */
+export function countExportableAliases(
+  aliases: AliasExportRecord[],
+  mode: AliasExportMode = 'mail_url',
+): number {
+  if (mode === 'account') return aliases.length
+  return aliases.filter((alias) => String(alias.share_token || '').trim()).length
 }
 
 export function downloadTextFile(filename: string, content: string): void {

--- a/frontend/src/lib/mailImport.ts
+++ b/frontend/src/lib/mailImport.ts
@@ -1,0 +1,38 @@
+/**
+ * 「邮箱导入」下面还分四个视图：Outlook / Hotmail / MailAPI URL 走同一个微软号池，
+ * AppleMail 走本地池文件。视图选择存在配置项 `mail_import_source` 里，`mail_provider`
+ * 只记到号池粒度，所以不能拿它反推视图——那样选什么都会退回 Outlook。
+ */
+export type MailImportSource = 'applemail' | 'outlook' | 'hotmail' | 'mailapi'
+
+export const MAIL_IMPORT_SOURCES: MailImportSource[] = ['applemail', 'outlook', 'hotmail', 'mailapi']
+
+export const MAIL_IMPORT_SOURCE_OPTIONS: { value: MailImportSource; label: string }[] = [
+  { value: 'outlook', label: 'Outlook（微软号池）' },
+  { value: 'hotmail', label: 'Hotmail（微软号池）' },
+  { value: 'mailapi', label: 'MailAPI URL（邮箱----mailapi_url）' },
+  { value: 'applemail', label: 'AppleMail / 小苹果' },
+]
+
+/** 后端把这些 mail_provider 值显示成「邮箱导入」 */
+export const MAIL_IMPORT_PROVIDERS = ['microsoft', 'outlook', 'applemail']
+
+const LEGACY_SOURCE_ALIASES: Record<string, MailImportSource> = { microsoft: 'outlook' }
+
+export function isMailImportProvider(mailProvider: string): boolean {
+  return MAIL_IMPORT_PROVIDERS.includes(String(mailProvider || '').trim().toLowerCase())
+}
+
+export function normalizeMailImportSource(value: unknown, mailProvider: unknown = ''): MailImportSource {
+  const raw = String(value ?? '').trim().toLowerCase()
+  const aliased = LEGACY_SOURCE_ALIASES[raw] ?? raw
+  if ((MAIL_IMPORT_SOURCES as string[]).includes(aliased)) {
+    return aliased as MailImportSource
+  }
+  return String(mailProvider ?? '').trim().toLowerCase() === 'applemail' ? 'applemail' : 'outlook'
+}
+
+export function resolveEffectiveMailProvider(mailProvider: string, mailImportSource: unknown): string {
+  if (mailProvider !== 'mail_import') return mailProvider
+  return normalizeMailImportSource(mailImportSource) === 'applemail' ? 'applemail' : 'microsoft'
+}

--- a/frontend/src/pages/ICloud.tsx
+++ b/frontend/src/pages/ICloud.tsx
@@ -61,6 +61,7 @@ import {
   ALIAS_EXPORT_FILENAME,
   ICLOUD_REGION_OPTIONS,
   aliasMailUrl,
+  countExportableAliases,
   downloadTextFile,
   formatAliasExport,
   formatDateTime,
@@ -159,8 +160,18 @@ export default function ICloudPage() {
 
   const exportAliases = (mode: AliasExportMode) => {
     if (targetAliases.length === 0) return
+    const exportable = countExportableAliases(targetAliases, mode)
+    if (exportable === 0) {
+      message.warning('选中的隐私邮箱都还没有邮件 URL，导不出内容')
+      return
+    }
     downloadTextFile(ALIAS_EXPORT_FILENAME, formatAliasExport(targetAliases, mode))
-    message.success(`已导出 ${targetAliases.length} 条`)
+    const skipped = targetAliases.length - exportable
+    if (skipped > 0) {
+      message.warning(`已导出 ${exportable} 条，${skipped} 条没有邮件 URL 已跳过`)
+      return
+    }
+    message.success(`已导出 ${exportable} 条`)
   }
 
   const accountColumns = [
@@ -414,10 +425,10 @@ export default function ICloudPage() {
                   <Dropdown.Button
                     icon={<DownOutlined />}
                     disabled={targetAliases.length === 0}
-                    onClick={() => exportAliases('self')}
+                    onClick={() => exportAliases('mail_url')}
                     menu={{
                       items: [
-                        { key: 'self', label: '隐私邮箱----隐私邮箱' },
+                        { key: 'mail_url', label: '隐私邮箱----邮件 URL' },
                         { key: 'account', label: '隐私邮箱----所属主号' },
                       ],
                       onClick: ({ key }) => exportAliases(key as AliasExportMode),

--- a/frontend/src/pages/RegisterTaskPage.tsx
+++ b/frontend/src/pages/RegisterTaskPage.tsx
@@ -39,14 +39,15 @@ import {
   DEFAULT_REGISTER_RETRY_TIMES,
   normalizeRegisterRetryTimes,
 } from '@/lib/registerRetry'
+import {
+  MAIL_IMPORT_SOURCE_OPTIONS,
+  isMailImportProvider,
+  normalizeMailImportSource,
+  resolveEffectiveMailProvider,
+} from '@/lib/mailImport'
 import { apiFetch } from '@/lib/utils'
 
 const { Text } = Typography
-
-function resolveEffectiveMailProvider(mailProvider: string, mailImportSource: string) {
-  if (mailProvider !== 'mail_import') return mailProvider
-  return mailImportSource === 'applemail' ? 'applemail' : 'microsoft'
-}
 
 export default function RegisterTaskPage() {
   const [form] = Form.useForm()
@@ -70,13 +71,13 @@ export default function RegisterTaskPage() {
     apiFetch('/config').then((cfg) => {
       const currentPlatform = form.getFieldValue('platform') || 'chatgpt'
       const configMailProvider = String(cfg.mail_provider || 'luckmail')
-      const isMailImportProvider = configMailProvider === 'microsoft' || configMailProvider === 'outlook' || configMailProvider === 'applemail'
+      const usesMailImport = isMailImportProvider(configMailProvider)
       form.setFieldsValue({
         executor_type: normalizeExecutorForPlatform(currentPlatform, cfg.default_executor),
         captcha_solver: cfg.default_captcha_solver || 'yescaptcha',
         register_retry_times: normalizeRegisterRetryTimes(cfg.register_retry_times),
-        mail_provider: isMailImportProvider ? 'mail_import' : configMailProvider,
-        mail_import_source: configMailProvider === 'applemail' ? 'applemail' : 'microsoft',
+        mail_provider: usesMailImport ? 'mail_import' : configMailProvider,
+        mail_import_source: normalizeMailImportSource(cfg.mail_import_source, configMailProvider),
         applemail_base_url: cfg.applemail_base_url || 'https://www.appleemail.top',
         applemail_pool_dir: cfg.applemail_pool_dir || 'mail',
         applemail_pool_file: cfg.applemail_pool_file || '',
@@ -270,7 +271,7 @@ export default function RegisterTaskPage() {
         executor_type: 'protocol',
         captcha_solver: 'yescaptcha',
         mail_provider: 'luckmail',
-        mail_import_source: 'microsoft',
+        mail_import_source: 'outlook',
         applemail_base_url: 'https://www.appleemail.top',
         applemail_pool_dir: 'mail',
         applemail_mailboxes: 'INBOX,Junk',
@@ -405,13 +406,13 @@ export default function RegisterTaskPage() {
             />
           </Form.Item>
           {mailProviderRaw === 'mail_import' && (
-            <Form.Item name="mail_import_source" label="导入类型" rules={[{ required: true }]}>
-              <Select
-                options={[
-                  { value: 'microsoft', label: '微软邮箱（Outlook / Hotmail）' },
-                  { value: 'applemail', label: 'AppleMail / 小苹果' },
-                ]}
-              />
+            <Form.Item
+              name="mail_import_source"
+              label="导入类型"
+              rules={[{ required: true }]}
+              extra="Outlook / Hotmail / MailAPI URL 共用同一个微软号池，运行时按账号自身的类型决定用 Graph/IMAP 还是轮询 mailapi_url。"
+            >
+              <Select options={MAIL_IMPORT_SOURCE_OPTIONS} />
             </Form.Item>
           )}
           {mailProvider === 'microsoft' && (

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -20,12 +20,12 @@ import { ICLOUD_REGION_OPTIONS } from '@/lib/icloud'
 import { parseCountryIdList } from '@/lib/smsCountries'
 import SmsCountrySelect from '@/components/SmsCountrySelect'
 import MailImportPanel from '@/components/settings/MailImportPanel'
+import {
+  isMailImportProvider,
+  normalizeMailImportSource,
+  resolveEffectiveMailProvider,
+} from '@/lib/mailImport'
 import { apiFetch } from '@/lib/utils'
-
-function resolveEffectiveMailProvider(mailProvider: string, mailImportSource: string) {
-  if (mailProvider !== 'mail_import') return mailProvider
-  return mailImportSource === 'applemail' ? 'applemail' : 'microsoft'
-}
 
 const SELECT_FIELDS: Record<string, { label: string; value: string }[]> = {
   mail_provider: [
@@ -1372,7 +1372,7 @@ export default function Settings() {
   const [saved, setSaved] = useState(false)
   const [activeTab, setActiveTab] = useState('register')
   const currentMailProviderRaw = String(Form.useWatch('mail_provider', form) || '')
-  const currentMailImportSource = String(Form.useWatch('mail_import_source', form) || 'microsoft')
+  const currentMailImportSource = normalizeMailImportSource(Form.useWatch('mail_import_source', form))
   const currentMailProvider = resolveEffectiveMailProvider(currentMailProviderRaw, currentMailImportSource)
   const showFloatingSaveButton = activeTab === 'mailbox' || activeTab === 'chatgpt'
   const contentPaneRef = useRef<HTMLDivElement | null>(null)
@@ -1381,7 +1381,7 @@ export default function Settings() {
   useEffect(() => {
     apiFetch('/config').then((data) => {
       const configMailProvider = String(data.mail_provider || 'luckmail')
-      const isMailImportProvider = configMailProvider === 'microsoft' || configMailProvider === 'outlook' || configMailProvider === 'applemail'
+      const usesMailImport = isMailImportProvider(configMailProvider)
       if (!data.mail_provider) {
         data.mail_provider = 'luckmail'
       }
@@ -1430,8 +1430,8 @@ export default function Settings() {
       if (!String(data.email_domain_level_count ?? '').trim()) {
         data.email_domain_level_count = 2
       }
-      data.mail_import_source = configMailProvider === 'applemail' ? 'applemail' : 'microsoft'
-      data.mail_provider = isMailImportProvider ? 'mail_import' : configMailProvider
+      data.mail_import_source = normalizeMailImportSource(data.mail_import_source, configMailProvider)
+      data.mail_provider = usesMailImport ? 'mail_import' : configMailProvider
       form.setFieldsValue(data)
     })
   }, [form])
@@ -1473,8 +1473,10 @@ export default function Settings() {
     setSaving(true)
     try {
       const values = form.getFieldsValue(true)
+      // 视图（Outlook / Hotmail / MailAPI URL / AppleMail）本身要落库，否则退出设置页
+      // 再回来只能按 mail_provider 反推，MailAPI URL 永远退回 Outlook
+      values.mail_import_source = normalizeMailImportSource(values.mail_import_source, values.mail_provider)
       values.mail_provider = resolveEffectiveMailProvider(values.mail_provider, values.mail_import_source)
-      delete values.mail_import_source
       const domains = normalizeDomainList(values.cfworker_domains)
       const enabledDomains = normalizeDomainList(values.cfworker_enabled_domains).filter((domain) => domains.includes(domain))
 
@@ -1514,8 +1516,8 @@ export default function Settings() {
 
       await apiFetch('/config', { method: 'PUT', body: JSON.stringify({ data: values }) })
       form.setFieldsValue({
-        mail_provider: values.mail_provider === 'microsoft' || values.mail_provider === 'applemail' ? 'mail_import' : values.mail_provider,
-        mail_import_source: values.mail_provider === 'applemail' ? 'applemail' : 'microsoft',
+        mail_provider: isMailImportProvider(values.mail_provider) ? 'mail_import' : values.mail_provider,
+        mail_import_source: values.mail_import_source,
         cpa_enabled: values.cpa_enabled,
         sub2api_enabled: values.sub2api_enabled,
         cfworker_domains: domains,

--- a/services/mail_imports/__init__.py
+++ b/services/mail_imports/__init__.py
@@ -1,3 +1,10 @@
+from .import_source import (
+    MAIL_IMPORT_PROVIDERS,
+    MAIL_IMPORT_SOURCES,
+    align_source_with_provider,
+    normalize_mail_import_source,
+    resolve_mail_provider_from_source,
+)
 from .registry import mail_import_registry
 from .schemas import (
     MailImportBatchDeleteRequest,
@@ -11,6 +18,11 @@ from .schemas import (
 )
 
 __all__ = [
+    "MAIL_IMPORT_PROVIDERS",
+    "MAIL_IMPORT_SOURCES",
+    "align_source_with_provider",
+    "normalize_mail_import_source",
+    "resolve_mail_provider_from_source",
     "mail_import_registry",
     "MailImportBatchDeleteRequest",
     "MailImportDeleteItem",

--- a/services/mail_imports/import_source.py
+++ b/services/mail_imports/import_source.py
@@ -1,0 +1,59 @@
+"""邮箱导入面板选中的那一栏（导入类型）。
+
+`mail_provider` 只区分到"微软邮箱池 / 小苹果邮箱池"，可微软那一侧在界面上又拆成
+Outlook、Hotmail、MailAPI URL 三个视图。视图选择以前没地方落库，退出设置页再回来
+就只能按 `mail_provider` 反推，永远反推成 Outlook——选了 MailAPI URL 也留不住。
+这里把视图本身作为一个配置项存下来，运行时仍旧按账号的 account_type 决定取码方式。
+"""
+
+from __future__ import annotations
+
+MAIL_IMPORT_SOURCE_APPLEMAIL = "applemail"
+MAIL_IMPORT_SOURCE_OUTLOOK = "outlook"
+MAIL_IMPORT_SOURCE_HOTMAIL = "hotmail"
+MAIL_IMPORT_SOURCE_MAILAPI = "mailapi"
+
+MAIL_IMPORT_SOURCES = (
+    MAIL_IMPORT_SOURCE_APPLEMAIL,
+    MAIL_IMPORT_SOURCE_OUTLOOK,
+    MAIL_IMPORT_SOURCE_HOTMAIL,
+    MAIL_IMPORT_SOURCE_MAILAPI,
+)
+
+# 旧版本只存 microsoft/applemail 两个值，microsoft 落到默认视图 Outlook
+_LEGACY_SOURCE_ALIASES = {"microsoft": MAIL_IMPORT_SOURCE_OUTLOOK}
+
+# mail_provider 取这些值时，界面上显示的是"邮箱导入"
+MAIL_IMPORT_PROVIDERS = ("microsoft", "outlook", MAIL_IMPORT_SOURCE_APPLEMAIL)
+
+
+def normalize_mail_import_source(value: object, mail_provider: object = "") -> str:
+    """把任意输入收敛成四个合法视图之一，缺值时按 mail_provider 兜底。"""
+    text = str(value or "").strip().lower()
+    text = _LEGACY_SOURCE_ALIASES.get(text, text)
+    if text in MAIL_IMPORT_SOURCES:
+        return text
+
+    provider = str(mail_provider or "").strip().lower()
+    if provider == MAIL_IMPORT_SOURCE_APPLEMAIL:
+        return MAIL_IMPORT_SOURCE_APPLEMAIL
+    return MAIL_IMPORT_SOURCE_OUTLOOK
+
+
+def resolve_mail_provider_from_source(value: object) -> str:
+    """视图 → 真正跑起来的邮箱服务。三个微软视图共用同一个号池。"""
+    source = normalize_mail_import_source(value)
+    if source == MAIL_IMPORT_SOURCE_APPLEMAIL:
+        return MAIL_IMPORT_SOURCE_APPLEMAIL
+    return "microsoft"
+
+
+def align_source_with_provider(value: object, mail_provider: object) -> str:
+    """provider 和视图打架时以 provider 为准，避免存出"小苹果池 + MailAPI 视图"。"""
+    source = normalize_mail_import_source(value, mail_provider)
+    provider = str(mail_provider or "").strip().lower()
+    if provider == MAIL_IMPORT_SOURCE_APPLEMAIL:
+        return MAIL_IMPORT_SOURCE_APPLEMAIL
+    if provider in {"microsoft", "outlook"} and source == MAIL_IMPORT_SOURCE_APPLEMAIL:
+        return MAIL_IMPORT_SOURCE_OUTLOOK
+    return source

--- a/tests/fixtures/shared_mail_chatgpt_otp.html
+++ b/tests/fixtures/shared_mail_chatgpt_otp.html
@@ -1,0 +1,246 @@
+<!doctype html><html lang="zh-CN"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>你的 ChatGPT 临时验证码 · alias.sample@icloud.com</title>
+<style>
+  :root{color-scheme:dark;}
+  *{box-sizing:border-box;}
+  body{margin:0;padding:24px 16px;background:#161922;color:#d7dce5;
+    font:14px/1.7 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;}
+  .card{max-width:860px;margin:0 auto;background:#1e212c;border:1px solid rgba(255,255,255,.09);
+    border-radius:12px;overflow:hidden;box-shadow:0 12px 40px rgba(0,0,0,.32);}
+  .head{padding:20px 24px;border-bottom:1px solid rgba(255,255,255,.09);}
+  .subject{margin:0 0 10px;font-size:18px;font-weight:600;word-break:break-word;}
+  .meta{color:#a4adbd;font-size:13px;word-break:break-word;}
+  .meta span{color:#7b8595;}
+  .body{padding:0;background:#f7f8fa;}
+  iframe{display:block;width:100%;border:0;background:#f7f8fa;}
+  .text{padding:20px 24px;white-space:pre-wrap;word-break:break-word;color:#c3cad6;}
+  .foot{display:flex;justify-content:space-between;gap:12px;align-items:center;
+    padding:14px 24px;border-top:1px solid rgba(255,255,255,.09);color:#7b8595;font-size:12px;}
+  a.button{color:#5f82b8;text-decoration:none;border:1px solid rgba(95,130,184,.4);
+    border-radius:8px;padding:6px 14px;background:rgba(95,130,184,.16);}
+  a.button:hover{color:#7396c8;}
+  .empty{padding:48px 24px;text-align:center;color:#7b8595;}
+</style></head>
+<body><div class="card"><div class="head"><h1 class="subject">你的 ChatGPT 临时验证码</h1><div class="meta">ChatGPT <span>&lt;<a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="0769687562776b7e58667358736a5868776269666e5864686a5871307163643361326c77756c3365586163657736363036476e646b6872632964686a">[email&#160;protected]</a>&gt;</span></div><div class="meta"><span>发往</span> <a href="/cdn-cgi/l/email-protection" class="__cf_email__" data-cfemail="630e0a1706114d10170c0f0a073c510f230a000f0c16074d000c0e">[email&#160;protected]</a> · 2026-08-20 18:19:32</div></div><div class="body"><iframe title="邮件正文" sandbox="allow-same-origin" srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;head&gt;&lt;meta charset=&quot;utf-8&quot;&gt;&lt;meta http-equiv=&quot;Content-Security-Policy&quot; content=&quot;script-src &#x27;none&#x27;&quot;&gt;&lt;style&gt;html,body{margin:0;padding:16px;background:#f7f8fa;color:#2f3540;font:14px/1.7 -apple-system,BlinkMacSystemFont,&quot;Segoe UI&quot;,Roboto,&quot;Helvetica Neue&quot;,Arial,sans-serif;word-break:break-word;overflow-wrap:anywhere;}img,table{max-width:100%!important;height:auto;}a{color:#3f6ea8;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;html&gt;
+  &lt;head&gt;
+    
+    &lt;title&gt;你的 ChatGPT 临时验证码&lt;/title&gt;
+    
+    &lt;meta name=&quot;viewport&quot; content=&quot;width=device-width, initial-scale=1&quot; /&gt;
+    &lt;style type=&quot;text/css&quot;&gt;
+      @font-face {
+        font-family: &quot;Söhne&quot;;
+        src: url(https://cdn.openai.com/common/fonts/soehne/soehne-buch.woff2)
+            format(&quot;woff2&quot;);
+        font-style: normal;
+        font-weight: 400;
+        font-display: swap;
+      }
+      .ExternalClass,
+      .ExternalClass div,
+      .ExternalClass font,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass td,
+      img {
+        line-height: 100%;
+      }
+      #outlook a {
+        padding: 0;
+      }
+      .ExternalClass,
+      .ReadMsgBody {
+        width: 100%;
+      }
+      a,
+      blockquote,
+      body,
+      li,
+      p,
+      table,
+      td {
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+      table,
+      td {
+        mso-table-lspace: 0;
+        mso-table-rspace: 0;
+      }
+      img {
+        -ms-interpolation-mode: bicubic;
+        border: 0;
+        height: auto;
+        outline: 0;
+        text-decoration: none;
+      }
+      table {
+        border-collapse: collapse !important;
+      }
+      #bodyCell,
+      #bodyTable,
+      body {
+          height: 100% !important;
+          margin: 0;
+          padding: 0;
+          font-family: Söhne, Roboto, Helvetica, Arial, sans-serif;
+        }
+
+      #bodyCell {
+        padding: 20px;
+      }
+      #bodyTable {
+        width: 560px;
+      }
+      @media only screen and (max-width: 480px) {
+        #bodyCell,
+        #bodyTable,
+        body {
+          width: 100% !important;
+        }
+        a,
+        blockquote,
+        body,
+        li,
+        p,
+        table,
+        td {
+          -webkit-text-size-adjust: none !important;
+        }
+        body {
+          min-width: 100% !important;
+        }
+        #bodyTable {
+          max-width: 560px !important;
+        }
+        #signIn {
+          max-width: 280px !important;
+        }
+      }
+    &lt;/style&gt;
+    &lt;!--[if mso]&gt;
+        &lt;style type=&quot;text/css&quot;&gt;
+          #bodyCell,
+          #bodyTable,
+          body {
+            font-family: Helvetica, Arial, sans-serif; !important
+          }
+        &lt;/style&gt;
+    &lt;![endif]--&gt;
+
+  &lt;/head&gt;
+  &lt;body&gt;
+    &lt;center&gt;
+      &lt;table
+        style=&quot;width: 560px;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 0;border-collapse: collapse !important;height: 100% !important;background-color: #ffffff;&quot;
+        align=&quot;center&quot;
+        border=&quot;0&quot;
+        cellpadding=&quot;0&quot;
+        cellspacing=&quot;0&quot;
+        height=&quot;100%&quot;
+        width=&quot;100%&quot;
+        id=&quot;bodyTable&quot;
+      &gt;
+        &lt;tr&gt;
+          &lt;td
+            align=&quot;center&quot;
+            valign=&quot;top&quot;
+            id=&quot;bodyCell&quot;
+            style=&quot;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 0 16px;height: 100% !important;&quot;
+          &gt;
+            &lt;div class=&quot;top&quot; style=&quot;background-color: #ffffff;color:#202123; padding: 56px 0 32px 0;&quot;&gt;
+              &lt;p
+                style=&quot;text-align: left;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; margin: 0;&quot;
+              &gt;
+                
+                &lt;img
+                  src=&quot;https://cdn.mcauto-images-production.sendgrid.net/d4ef4a73d51fe844/b7626bee-28ca-4e2f-b25b-7d81af34e7a1/206x51.png&quot;
+                  width=&quot;206&quot;
+                  height=&quot;51&quot;
+                  alt=&quot;ChatGPT&quot;
+                  title=&quot;&quot;
+                  style=&quot;height:36px;width:auto;-ms-interpolation-mode: bicubic;border: 0;line-height: 100%;outline: none;text-decoration: none;&quot;
+                &gt;
+                
+              &lt;/p&gt;
+            &lt;/div&gt;
+            &lt;table
+              class=&quot;main&quot;
+            &gt;
+              &lt;tr&gt;
+                  &lt;td style=&quot;background-color: #ffffff;color:#353740; text-align: left; line-height:1.5;&quot;&gt;
+
+                      
+
+
+                      &lt;p style=&quot;font-size: 16px; line-height: 24px; margin: 0;&quot;&gt;
+                        输入此临时验证码以继续：
+                      &lt;/p&gt;
+
+                      &lt;p style=&quot;font-family: Menlo, Monaco, Lucida Console, Arial; font-size: 24px; line-height: 28px; background-color: #F3F3F3; color: #5D5D5D; border-radius: 16px; padding: 28px 24px; margin: 24px 0;&quot;&gt;
+                        &lt;!--[if mso]&gt;
+                            &lt;span style=&quot;font-family: Lucida Console, Arial, sans-serif;&quot;&gt;
+                        &lt;![endif]--&gt;
+                        993177
+                        &lt;!--[if mso]&gt;
+                            &lt;/span&gt;
+                        &lt;![endif]--&gt;
+                      &lt;/p&gt;
+
+                      &lt;p style=&quot;font-size: 16px; line-height: 24px; text-align: left; margin: 0; margin-bottom: 24px;&quot;&gt;
+                        如果并非你本人尝试创建 ChatGPT 账户，请忽略此电子邮件。
+                      &lt;/p&gt;
+
+                      &lt;p style=&quot;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; margin: 0; color: #8F8F8F;&quot;&gt;
+                        &lt;br/&gt;谨致问候&lt;br/&gt;ChatGPT 团队
+                      &lt;/p&gt;
+                  &lt;/td&gt;
+              &lt;/tr&gt;
+
+              &lt;tr&gt;
+                &lt;td&gt;
+                    &lt;p style=&quot;height: 1px; width: 100%; background: #E5E5E5; margin: 40px 0;&quot;&gt;&lt;/p&gt;
+                &lt;/td&gt;
+              &lt;/tr&gt;
+            &lt;/table&gt;
+            &lt;table
+              class=&quot;footer&quot;
+              style=&quot;text-align: left;background: #ffffff;color:#6e6e80;width: 100%;&quot;
+            &gt;
+                &lt;tr&gt;
+                    &lt;td&gt;
+                        
+                        &lt;img
+                        src=&quot;https://cdn.mcauto-images-production.sendgrid.net/d4ef4a73d51fe844/b7626bee-28ca-4e2f-b25b-7d81af34e7a1/206x51.png&quot;
+                        width=&quot;206&quot;
+                        height=&quot;51&quot;
+                        alt=&quot;ChatGPT&quot;
+                        title=&quot;&quot;
+                        style=&quot;width:64px;height:auto;-ms-interpolation-mode: bicubic;border: 0;line-height: 100%;outline: none;text-decoration: none;margin-bottom: 16px;&quot;
+                    &gt;
+                        
+
+                    &lt;/td&gt;
+                &lt;/tr&gt;
+                &lt;tr&gt;
+                    &lt;td style=&quot;font-size: 12px; line-height: 16px; padding-bottom: 16px;&quot;&gt;
+                        &lt;p style=&quot;margin: 0;&quot;&gt;
+                            
+                                &lt;a style=&quot;color: #8F8F8F&quot; href=&quot;http://url3243.email.openai.com/ls/click?upn=u001.IQLfsj4kk-2BK7JhymNusRMtxuwNyiH8tHYK-2BH0HuuCVk-3D-a4u_Y8I-2BT0IKaKMEq9TnsEB-2B9FDFsXcDzMUS1O9Ll-2FwPl8iCFw5jgQZAIjVOxRMJGWSsHJ-2Bu6GeLwzWJ5bA-2FU4NPfb7lzL5SocVgXg9VcepJz7XYHE3oI-2BER0GwntQj-2F-2F2i5wPXNiVXmil1N-2FLVG7NPCOIR6UFkmrzoJAjHrDQ9tnygsSawSwu02T-2BlgYTmJKoW5hQEfuopEES-2BmY6karExVbN8l1KwtDNzXgfs8n62eU-2FZqeL6lTOhNFcEeeZSGzzWGgw2lqOVwh7OJuGryZ4Moi0a2tPIc8kugwgppQYY-2Bxh-2FyDboMQ0wgKVbKZ2W6goFivtCKNFlrr31PiTuPhfSlJH2y6XLD7tvTqqnyYGkHIEfOS08UBuM-2BYpw28akNATo7QEiqj7ZkbZ2BpqE-2FbRQtMVVRm-2FXEHFRFA8P-2BzIAv7Fc-3D&quot;&gt;ChatGPT&lt;/a&gt;
+                            
+
+                        &lt;/p&gt;
+                        &lt;p style=&quot;margin: 0;&quot;&gt;
+                            &lt;a style=&quot;color: #8F8F8F&quot; href=&quot;http://url3243.email.openai.com/ls/click?upn=u001.IQLfsj4kk-2BK7JhymNusRMmfwoG2v3nTgHW39-2Fobue0tn1LK51XoZKbBfyGht7CMaDij2_Y8I-2BT0IKaKMEq9TnsEB-2B9FDFsXcDzMUS1O9Ll-2FwPl8iCFw5jgQZAIjVOxRMJGWSsHJ-2Bu6GeLwzWJ5bA-2FU4NPfb7lzL5SocVgXg9VcepJz7XYHE3oI-2BER0GwntQj-2F-2F2i5wPXNiVXmil1N-2FLVG7NPCOIR6UFkmrzoJAjHrDQ9tnygsSawSwu02T-2BlgYTmJKoW5hQEfuopEES-2BmY6karExVbN8l1KwtDNzXgfs8n62eU-2FZqeL6lTOhNFcEeeZSGzzWG28JyOw35yM-2FepnJJxlLkGDpmKFDhWiL-2FqnxJEkOsFPO9UHLYTBPRhkpjFfRJzfToWxU2YQ-2Fus1bTdCDyRHokmMCt3SNINos7xFo4yOgdyv8BKc-2FPDHcuksmjjrCqB45nwCCeG7wmAFHhl9F3bECFOEFqUNFUAHxLR4AD5K2-2BD2M-3D&quot;&gt;帮助中心&lt;/a&gt;
+                        &lt;/p&gt;
+                    &lt;/td&gt;
+                &lt;/tr&gt;
+            &lt;/table&gt;
+          &lt;/td&gt;
+        &lt;/tr&gt;
+      &lt;/table&gt;
+    &lt;/center&gt;
+  &lt;img src=&quot;http://url3243.email.openai.com/wf/open?upn=u001.7BpDZJ0hizUs45FiB5SuBBc8e4YtIwR7jrkS90ZDDer3bpFRW5AUqwg4xpn2xWPR1zgxlEkIt4JBjy-2FgJKYrW9qYqMkU7Bgb3LL2jZNHT65wF1hB1fWfzy-2FQhkyqJycGPvlPughl0RFMzG0IoRNwMwvngPOsFDSzSIzNPRSfK29eboOAhxEGi0llW-2FKCy0ylzsqhrUfj4Lwkvu-2B6Fi0wqqNklgWkv7vXFDtSsG6nbK1FvB1MZJh-2FSvUfN5Giv0QlxjFPZFpvCx7ZWNBQbn-2F6zsky-2FbsTQXp9FvAEwwsVyctrn758ak58srjm9nQxGEJ7buYiMykYuZeK-2FrPseot4VBlt2Tv0dAmiumlCQlZtkBUO3R45mqVlV2LU3dDeh8m9wOQYkWWEeViamxlYtOmU9I9PO-2FF60EXIiB-2FUpyud3eY-3D&quot; alt=&quot;&quot; width=&quot;1&quot; height=&quot;1&quot; border=&quot;0&quot; style=&quot;height:1px !important;width:1px !important;border-width:0 !important;margin-top:0 !important;margin-bottom:0 !important;margin-right:0 !important;margin-left:0 !important;padding-top:0 !important;padding-bottom:0 !important;padding-right:0 !important;padding-left:0 !important;&quot;/&gt;&lt;/body&gt;
+&lt;/html&gt;&lt;/body&gt;&lt;/html&gt;" onload="fit(this)" style="height:320px"></iframe><script data-cfasync="false" src="/cdn-cgi/scripts/5c5dd728/cloudflare-static/email-decode.min.js"></script><script>function fit(f){function m(){try{f.style.height=(f.contentDocument.body.scrollHeight+32)+'px';}catch(e){}}m();setTimeout(m,300);}</script></div><div class="foot"><span>只显示最新一封，收到新邮件后刷新即可</span><a class="button" href="">刷新</a></div></div></body></html>

--- a/tests/test_mail_import_source_config.py
+++ b/tests/test_mail_import_source_config.py
@@ -1,0 +1,95 @@
+"""邮箱导入面板选中的那一栏要能存住。
+
+以前只有 mail_provider（microsoft / applemail）落库，界面上的 Outlook / Hotmail /
+MailAPI URL 三个视图靠反推，反推不出 MailAPI URL——选完退出再进来就变回 Outlook。
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel, create_engine
+
+from services.mail_imports import (
+    align_source_with_provider,
+    normalize_mail_import_source,
+    resolve_mail_provider_from_source,
+)
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    import core.config_store as config_store_module
+    import core.db as db
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'config.db'}")
+    SQLModel.metadata.create_all(engine)
+    monkeypatch.setattr(db, "engine", engine)
+    monkeypatch.setattr(config_store_module, "engine", engine)
+
+    from main import app
+
+    return TestClient(app)
+
+
+@pytest.mark.parametrize(
+    ("stored", "provider", "expected"),
+    [
+        ("mailapi", "microsoft", "mailapi"),
+        ("hotmail", "microsoft", "hotmail"),
+        ("MailAPI", "microsoft", "mailapi"),
+        # 旧库里只有 microsoft/applemail 两个值
+        ("microsoft", "microsoft", "outlook"),
+        ("", "applemail", "applemail"),
+        ("", "microsoft", "outlook"),
+        ("", "luckmail", "outlook"),
+        ("nonsense", "applemail", "applemail"),
+    ],
+)
+def test_normalize_mail_import_source(stored, provider, expected):
+    assert normalize_mail_import_source(stored, provider) == expected
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("outlook", "microsoft"),
+        ("hotmail", "microsoft"),
+        ("mailapi", "microsoft"),
+        ("applemail", "applemail"),
+    ],
+)
+def test_three_microsoft_views_share_one_pool(source, expected):
+    assert resolve_mail_provider_from_source(source) == expected
+
+
+def test_provider_wins_when_the_two_disagree():
+    assert align_source_with_provider("mailapi", "applemail") == "applemail"
+    assert align_source_with_provider("applemail", "microsoft") == "outlook"
+    assert align_source_with_provider("mailapi", "microsoft") == "mailapi"
+    # provider 不是邮箱导入时视图照存，等用户切回来还是他选的那一栏
+    assert align_source_with_provider("mailapi", "luckmail") == "mailapi"
+
+
+def test_mailapi_view_survives_a_reload(client):
+    client.put(
+        "/api/config",
+        json={"data": {"mail_provider": "microsoft", "mail_import_source": "mailapi"}},
+    )
+
+    config = client.get("/api/config").json()
+
+    assert config["mail_import_source"] == "mailapi"
+    assert config["mail_provider"] == "microsoft"
+
+
+def test_panel_can_change_only_the_view(client):
+    client.put("/api/config", json={"data": {"mail_provider": "applemail"}})
+
+    client.put("/api/config", json={"data": {"mail_import_source": "mailapi"}})
+
+    assert client.get("/api/config").json()["mail_import_source"] == "mailapi"
+
+
+def test_config_without_a_stored_view_falls_back_instead_of_returning_blank(client):
+    client.put("/api/config", json={"data": {"mail_provider": "applemail"}})
+
+    assert client.get("/api/config").json()["mail_import_source"] == "applemail"

--- a/tests/test_mail_imports_service.py
+++ b/tests/test_mail_imports_service.py
@@ -46,6 +46,59 @@ class MailImportServiceTests(unittest.TestCase):
         self.assertEqual(record.account_type, "mailapi_url")
         self.assertEqual(record.mailapi_url, "https://mailapi.icu/key?type=html&orderNo=abc123")
 
+    def test_alias_mail_url_export_line_imports_as_mailapi_url(self):
+        """隐私邮箱导出的 `隐私邮箱----邮件 URL` 那一行，得能原样贴回邮箱导入。
+
+        导出串是前端拼的，但格式契约在这一侧：`/m/<share_token>` 这种免登录链接
+        必须被认成 mailapi_url，不然导出来的东西没地方用。
+        """
+        rules_module = load_microsoft_import_rules_module()
+        parse_microsoft_import_line = rules_module.parse_microsoft_import_line
+
+        record = parse_microsoft_import_line(
+            1,
+            "alias.sample@icloud.com----https://reg.example.com/m/y1urEDOgBNVeDE9aK5vUWA",
+        )
+
+        self.assertEqual(record.email, "alias.sample@icloud.com")
+        self.assertEqual(record.account_type, "mailapi_url")
+        self.assertEqual(
+            record.mailapi_url,
+            "https://reg.example.com/m/y1urEDOgBNVeDE9aK5vUWA",
+        )
+
+    def test_mailapi_only_batch_never_runs_the_oauth_probe(self):
+        from services.mail_imports.schemas import MailImportExecuteRequest
+        from services.mail_imports.providers import MicrosoftMailImportStrategy
+
+        strategy = MicrosoftMailImportStrategy()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_engine = create_engine(f"sqlite:///{Path(tmp_dir) / 'mailapi-only.db'}")
+            SQLModel.metadata.create_all(test_engine)
+
+            try:
+                with patch("services.mail_imports.providers.engine", test_engine), \
+                     patch("services.mail_imports.providers.OutlookMailbox") as mailbox_cls:
+                    response = strategy.execute(
+                        MailImportExecuteRequest(
+                            type="microsoft",
+                            content=(
+                                "one@icloud.com----https://reg.example.com/m/tokenone\n"
+                                "two@icloud.com----https://reg.example.com/m/tokentwo"
+                            ),
+                        )
+                    )
+
+                    mailbox_cls.assert_not_called()
+                    self.assertEqual(response.summary.success, 2)
+                    self.assertEqual(response.summary.failed, 0)
+                    self.assertEqual(
+                        {item.account_type for item in response.snapshot.items},
+                        {"mailapi_url"},
+                    )
+            finally:
+                test_engine.dispose()
+
     def test_rule_engine_returns_first_failure(self):
         rules_module = load_microsoft_import_rules_module()
         MicrosoftMailImportRecord = rules_module.MicrosoftMailImportRecord

--- a/tests/test_mailapi_url_otp_backend.py
+++ b/tests/test_mailapi_url_otp_backend.py
@@ -1,0 +1,80 @@
+"""MailAPI URL 号池的取码链路。
+
+`邮箱----mailapi_url` 这类账号运行时不走 Graph/IMAP，而是反复 GET 那个 URL 再从
+返回的网页里抠验证码。这里盯两件事：号池取号后确实路由到 MailAPI 后端，以及页面
+真拿到手时能把码抠出来——用一份真实的隐私邮箱分享页当样本。
+"""
+
+from pathlib import Path
+
+import pytest
+
+from core.base_mailbox import MailApiUrlOtpBackend, MailboxAccount, OutlookMailbox
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "shared_mail_chatgpt_otp.html"
+
+
+def _mailapi_account(url: str = "https://reg.example.com/m/tok") -> MailboxAccount:
+    return MailboxAccount(
+        email="alias.sample@icloud.com",
+        account_id="1",
+        extra={"account_type": "mailapi_url", "mailapi_url": url},
+    )
+
+
+def test_shared_mail_page_yields_the_chatgpt_code():
+    """分享页把邮件正文塞在 iframe 的 srcdoc 里，整页转义了一遍还得抠得出来。"""
+    backend = MailApiUrlOtpBackend(OutlookMailbox())
+
+    code = backend._extract_code(FIXTURE.read_text(encoding="utf-8"), None)
+
+    assert code == "993177"
+
+
+def test_content_before_a_blank_line_is_not_thrown_away():
+    """网页不是原始邮件，不能按邮件头那样从第一个空行处腰斩——码常在被砍掉的那半边。"""
+    backend = MailApiUrlOtpBackend(OutlookMailbox())
+    page = "<p>验证码 246813</p>\n\n<style>.pad{padding:0}</style>"
+
+    assert backend._extract_code(page, None) == "246813"
+
+
+def test_digits_inside_a_tracking_link_are_not_mistaken_for_the_code():
+    backend = MailApiUrlOtpBackend(OutlookMailbox())
+    page = "<p>http://t.example.com/wf/open?upn=u001.abc123456def</p><p>887766</p>"
+
+    assert backend._extract_code(page, None) == "887766"
+
+
+def test_wait_for_code_polls_the_url_until_a_new_code_shows_up(monkeypatch):
+    backend = MailApiUrlOtpBackend(OutlookMailbox())
+    pages = iter(["<p>还没有邮件</p>", "<p>验证码 135790</p>"])
+    monkeypatch.setattr(backend, "_fetch_mailapi_text", lambda _account: next(pages))
+    monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
+
+    assert backend.wait_for_code(_mailapi_account(), timeout=30) == "135790"
+
+
+def test_missing_url_is_reported_instead_of_silently_polling_nothing():
+    backend = MailApiUrlOtpBackend(OutlookMailbox())
+    account = MailboxAccount(email="a@b.com", extra={"account_type": "mailapi_url"})
+
+    with pytest.raises(RuntimeError, match="mailapi_url 为空"):
+        backend._fetch_mailapi_text(account)
+
+
+def test_mailapi_accounts_route_to_the_mailapi_backend():
+    """池子里 OAuth 和 MailAPI 是混着放的，选后端只能看账号自己的类型。"""
+    mailbox = OutlookMailbox()
+
+    assert mailbox._resolve_backend(_mailapi_account()) is mailbox._backends["mailapi_url"]
+
+    oauth_account = MailboxAccount(
+        email="demo@outlook.com",
+        extra={
+            "account_type": "microsoft_oauth",
+            "client_id": "cid",
+            "refresh_token": "rt",
+        },
+    )
+    assert mailbox._resolve_backend(oauth_account) is mailbox._backends["graph"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 修复邮箱导入选 MailAPI URL 后离开页面又变回 Outlook：新增持久化配置 `mail_import_source`
- 加固 MailAPI URL 网页 OTP 解析（本站 `/m/<token>` 共享页可正确提取；已对 https://reg.itcode.eu.cc/m/y1urEDOgBNVeDE9aK5vUWA 验证得到 `993177`）
- 隐私邮箱导出默认改为 `隐私邮箱----邮件 URL`（可直接再导入 MailAPI URL 号池）

## Test plan
- [x] pytest（含 mailapi_url OTP、import_source、导入分类）
- [x] frontend tsc / build
- [ ] 设置页选 MailAPI URL → 离开再进仍保持
- [ ] 导出隐私邮箱粘贴回 MailAPI URL 导入

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35260470-e43e-4abe-a670-08823bc564b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35260470-e43e-4abe-a670-08823bc564b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

