### PR TITLE
fix: MailAPI URL 导入视图刷新后仍保持

### DIFF
--- a/frontend/src/components/settings/MailImportPanel.tsx
+++ b/frontend/src/components/settings/MailImportPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { App, Alert, Button, Card, Form, Input, InputNumber, Popconfirm, Select, Space, Switch, Table, Tag, Typography } from 'antd'
 import type { FormInstance } from 'antd'
 
-import { normalizeMailImportSource, type MailImportSource } from '@/lib/mailImport'
+import { normalizeMailImportSource, useStoredMailImportSource, type MailImportSource } from '@/lib/mailImport'
 import { apiFetch } from '@/lib/utils'
 
 type MailImportProviderType = 'applemail' | 'microsoft'
@@ -77,11 +77,14 @@ function toImportApiType(value: MailImportSelectionType): MailImportProviderType
  * 选中哪一栏只看已保存的 `mail_import_source`。以前这里按 mail_provider 加
  * luckmail 域名反推，反推路径里没有 MailAPI URL 这个分支，于是选完再回来必然
  * 变回 Outlook。
+ *
+ * 配置还没加载回来时返回 null：这时候什么都反推不出来，别急着把用户拽到 Outlook。
  */
 function resolvePreferredImportType(
   currentMailProvider: string,
   mailImportSource: string,
-): MailImportSelectionType {
+): MailImportSelectionType | null {
+  if (!mailImportSource) return null
   return normalizeMailImportSource(mailImportSource, currentMailProvider)
 }
 
@@ -181,7 +184,7 @@ function buildResultMessage(result: MailImportResult) {
 export default function MailImportPanel({ form }: MailImportPanelProps) {
   const { message } = App.useApp()
   const currentMailProvider = String(Form.useWatch('mail_provider', form) || '')
-  const currentMailImportSource = String(Form.useWatch('mail_import_source', form) || '')
+  const storedMailImportSource = useStoredMailImportSource(form)
   const watchedPoolDir = String(Form.useWatch('applemail_pool_dir', form) || 'mail')
   const watchedPoolFile = String(Form.useWatch('applemail_pool_file', form) || '')
 
@@ -209,8 +212,8 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
   const selectedApiType = selectedProvider?.apiType ?? toImportApiType(selectedType)
   const supportsAliasSplit = selectedApiType === 'microsoft'
   const preferredImportType = useMemo(
-    () => resolvePreferredImportType(currentMailProvider, currentMailImportSource),
-    [currentMailImportSource, currentMailProvider],
+    () => resolvePreferredImportType(currentMailProvider, storedMailImportSource),
+    [storedMailImportSource, currentMailProvider],
   )
   const snapshot = useMemo(
     () => filterSnapshotBySelection(rawSnapshot, selectedType),
@@ -226,7 +229,7 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
 
   /**
    * 视图选择立刻落库，不等整页「保存」。用户在这里选完 MailAPI URL 就去别的页面
-   * 是常态，只留在表单里等于没选。失败了也不打扰——表单里那份还在。
+   * 是常态，只留在表单里等于没选。
    */
   const persistImportSource = async (value: MailImportSelectionType) => {
     try {
@@ -235,7 +238,9 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
         body: JSON.stringify({ data: { mail_import_source: value } }),
       })
     } catch {
-      // 忽略：下次点保存会把整份配置一起写回去
+      // 表单里那份还在，点「保存配置」还能补上；但得说一声，否则刷新回来又变 Outlook
+      // 会看起来像界面自己乱跳
+      message.warning('这一栏没能保存，刷新后可能变回 Outlook，点一下「保存配置」再试')
     }
   }
 
@@ -247,11 +252,12 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
       const displayProviders = buildDisplayProviders(items)
       setProviders(displayProviders)
 
-      if (displayProviders.some((item) => item.type === preferredImportType)) {
-        setSelectedType(preferredImportType)
-      } else if (displayProviders.length > 0) {
-        setSelectedType(displayProviders[0].type)
-      }
+      const available = new Set(displayProviders.map((item) => item.type))
+      setSelectedType((current) => {
+        if (preferredImportType && available.has(preferredImportType)) return preferredImportType
+        if (available.has(current)) return current
+        return displayProviders[0]?.type ?? current
+      })
     } catch (error) {
       const detail = error instanceof Error ? error.message : '加载邮箱导入配置失败'
       message.error(detail)
@@ -287,7 +293,7 @@ export default function MailImportPanel({ form }: MailImportPanelProps) {
   }, [])
 
   useEffect(() => {
-    if (providerMap.has(preferredImportType)) {
+    if (preferredImportType && providerMap.has(preferredImportType)) {
       setSelectedType(preferredImportType)
     }
   }, [preferredImportType, providerMap])

--- a/frontend/src/lib/mailImport.ts
+++ b/frontend/src/lib/mailImport.ts
@@ -3,6 +3,9 @@
  * AppleMail 走本地池文件。视图选择存在配置项 `mail_import_source` 里，`mail_provider`
  * 只记到号池粒度，所以不能拿它反推视图——那样选什么都会退回 Outlook。
  */
+import { Form } from 'antd'
+import type { FormInstance } from 'antd'
+
 export type MailImportSource = 'applemail' | 'outlook' | 'hotmail' | 'mailapi'
 
 export const MAIL_IMPORT_SOURCES: MailImportSource[] = ['applemail', 'outlook', 'hotmail', 'mailapi']
@@ -30,6 +33,19 @@ export function normalizeMailImportSource(value: unknown, mailProvider: unknown 
     return aliased as MailImportSource
   }
   return String(mailProvider ?? '').trim().toLowerCase() === 'applemail' ? 'applemail' : 'outlook'
+}
+
+/**
+ * 读设置页表单里的 `mail_import_source`，空串表示配置还没回来。
+ *
+ * 设置页没有这个字段的 Form.Item——视图选择器画在「邮箱导入」卡片头上，值只由
+ * setFieldsValue 写进 store。而 useWatch 默认盯的是注册过的字段（rc-field-form 里
+ * 是 getFieldsValue()），不带 preserve 就永远读到 undefined：库里明明存着 mailapi，
+ * 界面照样退回 Outlook。
+ */
+export function useStoredMailImportSource(form: FormInstance): string {
+  const watched = Form.useWatch('mail_import_source', { form, preserve: true })
+  return String(watched ?? '').trim().toLowerCase()
 }
 
 export function resolveEffectiveMailProvider(mailProvider: string, mailImportSource: unknown): string {

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -24,6 +24,7 @@ import {
   isMailImportProvider,
   normalizeMailImportSource,
   resolveEffectiveMailProvider,
+  useStoredMailImportSource,
 } from '@/lib/mailImport'
 import { apiFetch } from '@/lib/utils'
 
@@ -1372,7 +1373,7 @@ export default function Settings() {
   const [saved, setSaved] = useState(false)
   const [activeTab, setActiveTab] = useState('register')
   const currentMailProviderRaw = String(Form.useWatch('mail_provider', form) || '')
-  const currentMailImportSource = normalizeMailImportSource(Form.useWatch('mail_import_source', form))
+  const currentMailImportSource = normalizeMailImportSource(useStoredMailImportSource(form))
   const currentMailProvider = resolveEffectiveMailProvider(currentMailProviderRaw, currentMailImportSource)
   const showFloatingSaveButton = activeTab === 'mailbox' || activeTab === 'chatgpt'
   const contentPaneRef = useRef<HTMLDivElement | null>(null)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
修复「邮箱导入」选 MailAPI URL 后刷新仍显示 Outlook：
- `mail_import_source` 实际已写入配置，但前端 `Form.useWatch` 未 `preserve`，读不到未注册字段，每次都回落到 outlook
- 用 `useStoredMailImportSource`（`preserve: true`）读取；加载完成前不再 snap 回 Outlook

## Test plan
- [x] 本地 Chromium：选 MailAPI URL → 刷新仍保持，placeholder 为 `邮箱----mailapi_url`
- [x] 后端 mail_import_source 相关测试
- [ ] 生产部署后复现上述路径

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35260470-e43e-4abe-a670-08823bc564b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35260470-e43e-4abe-a670-08823bc564b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

