### PR TITLE
Fix proxy pool normalization accounting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ logs/
 accounts.txt
 *_accounts.txt
 account.txt
+proxies.txt
 mail/
 smstome_all_numbers.txt
 smstome*_numbers.txt

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [Docker 部署](#docker-部署)
 - [插件与外部依赖](#插件与外部依赖)
 - [常见问题排查](#常见问题排查)
+- [更新记录](#更新记录)
 - [项目结构](#项目结构)
 - [Electron 开发说明](#electron-开发说明)
 - [用户讨论群](#用户讨论群)
@@ -596,6 +597,15 @@ node --version
 ```
 
 Sentinel PoW 求解器要在 Node 沙箱里跑 OpenAI 的 `sdk.js`，没有 Node 时算出来的 token 过不了服务端复核，**验证码邮件会被静默丢弃**——日志上看不到明显报错，但码永远收不到。若 `node` 不在 `PATH` 里，用 `OPENAI_SENTINEL_NODE_PATH` 指定绝对路径。
+
+## 更新记录
+
+### 2026-08-28
+
+- 优化代理池对 `host:port:user:pass` 格式的兼容性，代理检测与浏览器执行器会使用一致的规范化代理配置。
+- 代理健康统计现在能准确回写到原始代理记录；检测成功会自动恢复启用，从未成功且连续失败的代理会自动停用。
+
+完整历史请查看 [docs/releases/release-notes.md](docs/releases/release-notes.md)。
 
 ## 项目结构
 

--- a/core/proxy_pool.py
+++ b/core/proxy_pool.py
@@ -1,11 +1,13 @@
-"""代理池 - 从数据库读取代理，支持轮询和按区域选取"""
+"""Proxy pool backed by the application database."""
 
-from typing import Optional
-from sqlmodel import Session, select
-from .db import ProxyModel, engine
-from .proxy_utils import build_requests_proxy_config
-import time, threading, random
 from datetime import datetime, timezone
+import threading
+from typing import Optional
+
+from sqlmodel import Session, select
+
+from .db import ProxyModel, engine
+from .proxy_utils import build_requests_proxy_config, normalize_proxy_url
 
 
 class ProxyPool:
@@ -13,8 +15,29 @@ class ProxyPool:
         self._index = 0
         self._lock = threading.Lock()
 
+    def _find_by_url(self, session: Session, url: str) -> ProxyModel | None:
+        p = session.exec(select(ProxyModel).where(ProxyModel.url == url)).first()
+        if p:
+            return p
+
+        normalized = normalize_proxy_url(url)
+        if not normalized:
+            return None
+
+        if normalized != url:
+            p = session.exec(
+                select(ProxyModel).where(ProxyModel.url == normalized)
+            ).first()
+            if p:
+                return p
+
+        for candidate in session.exec(select(ProxyModel)).all():
+            if normalize_proxy_url(candidate.url) == normalized:
+                return candidate
+        return None
+
     def get_next(self, region: str = "") -> Optional[str]:
-        """加权轮询取一个可用代理，在高成功率代理间轮换"""
+        """Return the next active proxy, biased toward higher success rate."""
         with Session(engine) as s:
             q = select(ProxyModel).where(ProxyModel.is_active == True)
             if region:
@@ -33,27 +56,27 @@ class ProxyPool:
 
     def report_success(self, url: str) -> None:
         with Session(engine) as s:
-            p = s.exec(select(ProxyModel).where(ProxyModel.url == url)).first()
+            p = self._find_by_url(s, url)
             if p:
                 p.success_count += 1
+                p.is_active = True
                 p.last_checked = datetime.now(timezone.utc)
                 s.add(p)
                 s.commit()
 
     def report_fail(self, url: str) -> None:
         with Session(engine) as s:
-            p = s.exec(select(ProxyModel).where(ProxyModel.url == url)).first()
+            p = self._find_by_url(s, url)
             if p:
                 p.fail_count += 1
                 p.last_checked = datetime.now(timezone.utc)
-                # 连续失败超过10次自动禁用
                 if p.fail_count > 0 and p.success_count == 0 and p.fail_count >= 5:
                     p.is_active = False
                 s.add(p)
                 s.commit()
 
     def check_all(self) -> dict:
-        """检测所有代理可用性"""
+        """Probe all configured proxies against a neutral endpoint."""
         import requests
 
         with Session(engine) as s:

--- a/core/proxy_utils.py
+++ b/core/proxy_utils.py
@@ -1,8 +1,54 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Optional
-from urllib.parse import unquote, urlsplit, urlunsplit
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
+
+
+@dataclass(frozen=True)
+class _LegacyProxyParts:
+    scheme: str
+    host: str
+    port: str
+    username: str = ""
+    password: str = ""
+
+
+def _parse_legacy_proxy(value: str) -> _LegacyProxyParts | None:
+    fields = value.split(":")
+    if len(fields) == 2 and fields[1].isdigit():
+        return _LegacyProxyParts("http", fields[0], fields[1])
+    if len(fields) == 4 and fields[1].isdigit():
+        return _LegacyProxyParts("http", fields[0], fields[1], fields[2], fields[3])
+    if len(fields) >= 5 and fields[2].isdigit() and fields[0].lower() in {
+        "http",
+        "https",
+        "socks4",
+        "socks5",
+        "socks5h",
+    }:
+        return _LegacyProxyParts(
+            fields[0].lower(),
+            fields[1],
+            fields[2],
+            fields[3],
+            ":".join(fields[4:]),
+        )
+    return None
+
+
+def _legacy_to_url(parts: _LegacyProxyParts) -> str:
+    scheme = "socks5h" if parts.scheme == "socks5" else parts.scheme
+    host = parts.host
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    auth = ""
+    if parts.username or parts.password:
+        username = quote(parts.username, safe="")
+        password = quote(parts.password, safe="")
+        auth = f"{username}:{password}@"
+    return f"{scheme}://{auth}{host}:{parts.port}"
 
 
 def _is_auth_socks_proxy(scheme: str, username: str, password: str) -> bool:
@@ -49,6 +95,10 @@ def normalize_proxy_url(proxy_url: Optional[str]) -> Optional[str]:
     if not value:
         return None
 
+    legacy = _parse_legacy_proxy(value)
+    if legacy:
+        return _legacy_to_url(legacy)
+
     parts = urlsplit(value)
     if (parts.scheme or "").lower() == "socks5":
         parts = parts._replace(scheme="socks5h")
@@ -56,17 +106,54 @@ def normalize_proxy_url(proxy_url: Optional[str]) -> Optional[str]:
     return value
 
 
+def redact_proxy_url(proxy_url: Optional[str]) -> str:
+    """Return a log-safe proxy URL without authentication credentials."""
+    value = str(proxy_url or "").strip()
+    if not value:
+        return ""
+
+    legacy = _parse_legacy_proxy(value)
+    if legacy and "://" not in value:
+        if legacy.username or legacy.password:
+            if value.split(":", 1)[0].lower() in {
+                "http",
+                "https",
+                "socks4",
+                "socks5",
+                "socks5h",
+            }:
+                return f"{legacy.scheme}:{legacy.host}:{legacy.port}:***:***"
+            return f"{legacy.host}:{legacy.port}:***:***"
+        return f"{legacy.host}:{legacy.port}"
+
+    parts = urlsplit(value)
+    if not parts.scheme:
+        return "(configured proxy)"
+
+    host = parts.hostname or ""
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    try:
+        port = f":{parts.port}" if parts.port is not None else ""
+    except ValueError:
+        return f"{parts.scheme}://(configured proxy)"
+    auth = (
+        "***:***@" if parts.username is not None or parts.password is not None else ""
+    )
+    return urlunsplit(
+        (parts.scheme, f"{auth}{host}{port}", parts.path, parts.query, parts.fragment)
+    )
+
+
 def build_requests_proxy_config(proxy_url: Optional[str]) -> Optional[dict[str, str]]:
-    if not proxy_url:
+    normalized = normalize_proxy_url(proxy_url)
+    if not normalized:
         return None
-    return {"http": proxy_url, "https": proxy_url}
+    return {"http": normalized, "https": normalized}
 
 
 def build_playwright_proxy_config(proxy_url: Optional[str]) -> Optional[dict[str, str]]:
-    if not proxy_url:
-        return None
-
-    value = str(proxy_url).strip()
+    value = normalize_proxy_url(proxy_url)
     if not value:
         return None
     parts = urlsplit(value)
@@ -77,8 +164,6 @@ def build_playwright_proxy_config(proxy_url: Optional[str]) -> Optional[dict[str
         return {"server": server}
 
     scheme = (parts.scheme or "").lower()
-    if _is_auth_socks_proxy(scheme, parts.username or "", parts.password or ""):
-        return None
     if scheme == "socks5h":
         scheme = "socks5"
 

--- a/docs/releases/release-notes.md
+++ b/docs/releases/release-notes.md
@@ -1,0 +1,7 @@
+# Release Notes
+
+### 2026-08-28
+
+- Improved proxy import compatibility for common `host:port:user:pass` entries so proxy checks and browser tasks can use the same stored pool consistently.
+- Proxy health accounting now updates the original stored proxy entry even when the runtime uses a normalized URL form.
+- Proxies that pass a neutral health check are re-enabled automatically, while never-successful proxies are disabled after repeated failures.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,3 +20,13 @@ import core.config_store  # noqa: E402,F401  注册 configs 表
 from core.db import init_db  # noqa: E402  必须在 DATABASE_URL 设好之后再 import
 
 init_db()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    from core.db import engine
+
+    engine.dispose()
+    try:
+        _TMP_DB_DIR.cleanup()
+    except PermissionError:
+        pass

--- a/tests/test_proxy_pool.py
+++ b/tests/test_proxy_pool.py
@@ -1,0 +1,62 @@
+from sqlmodel import Session, select
+
+from core.db import ProxyModel, engine
+from core.proxy_pool import ProxyPool
+
+
+def test_report_success_matches_legacy_proxy_after_normalization():
+    pool = ProxyPool()
+    raw = "proxy.example:2000:user-name:secret-pass"
+    normalized = "http://user-name:secret-pass@proxy.example:2000"
+
+    with Session(engine) as session:
+        proxy = ProxyModel(url=raw, is_active=False)
+        session.add(proxy)
+        session.commit()
+
+    pool.report_success(normalized)
+
+    with Session(engine) as session:
+        proxy = session.exec(select(ProxyModel).where(ProxyModel.url == raw)).one()
+        assert proxy.success_count == 1
+        assert proxy.fail_count == 0
+        assert proxy.is_active is True
+        assert proxy.last_checked is not None
+
+
+def test_report_fail_matches_legacy_proxy_after_normalization():
+    pool = ProxyPool()
+    raw = "proxy.example:2001:user-name:secret-pass"
+    normalized = "http://user-name:secret-pass@proxy.example:2001"
+
+    with Session(engine) as session:
+        proxy = ProxyModel(url=raw, is_active=True)
+        session.add(proxy)
+        session.commit()
+
+    pool.report_fail(normalized)
+
+    with Session(engine) as session:
+        proxy = session.exec(select(ProxyModel).where(ProxyModel.url == raw)).one()
+        assert proxy.success_count == 0
+        assert proxy.fail_count == 1
+        assert proxy.is_active is True
+        assert proxy.last_checked is not None
+
+
+def test_report_fail_disables_never_successful_proxy_after_threshold():
+    pool = ProxyPool()
+    raw = "proxy.example:2002:user-name:secret-pass"
+
+    with Session(engine) as session:
+        proxy = ProxyModel(url=raw, is_active=True, fail_count=4)
+        session.add(proxy)
+        session.commit()
+
+    pool.report_fail(raw)
+
+    with Session(engine) as session:
+        proxy = session.exec(select(ProxyModel).where(ProxyModel.url == raw)).one()
+        assert proxy.success_count == 0
+        assert proxy.fail_count == 5
+        assert proxy.is_active is False

--- a/tests/test_proxy_utils.py
+++ b/tests/test_proxy_utils.py
@@ -1,0 +1,67 @@
+from core.proxy_utils import (
+    build_playwright_proxy_config,
+    build_requests_proxy_config,
+    normalize_proxy_url,
+    redact_proxy_url,
+)
+
+
+def test_redact_proxy_url_hides_url_credentials():
+    redacted = redact_proxy_url("http://user-name:secret-pass@proxy.example:2000")
+
+    assert redacted == "http://***:***@proxy.example:2000"
+    assert "user-name" not in redacted
+    assert "secret-pass" not in redacted
+
+
+def test_redact_proxy_url_hides_legacy_credentials():
+    redacted = redact_proxy_url("proxy.example:2000:user-name:secret-pass")
+
+    assert redacted == "proxy.example:2000:***:***"
+
+
+def test_normalize_proxy_url_converts_legacy_credentials():
+    normalized = normalize_proxy_url("proxy.example:2000:user-name:secret-pass")
+
+    assert normalized == "http://user-name:secret-pass@proxy.example:2000"
+
+
+def test_normalize_proxy_url_escapes_legacy_credentials():
+    normalized = normalize_proxy_url("proxy.example:2000:user name:secret/pass")
+
+    assert normalized == "http://user%20name:secret%2Fpass@proxy.example:2000"
+
+
+def test_normalize_proxy_url_converts_socks5_to_remote_dns():
+    normalized = normalize_proxy_url("socks5://user:secret@proxy.example:2000")
+
+    assert normalized == "socks5h://user:secret@proxy.example:2000"
+
+
+def test_build_requests_proxy_config_normalizes_legacy_credentials():
+    config = build_requests_proxy_config("proxy.example:2000:user-name:secret-pass")
+
+    assert config == {
+        "http": "http://user-name:secret-pass@proxy.example:2000",
+        "https": "http://user-name:secret-pass@proxy.example:2000",
+    }
+
+
+def test_build_playwright_proxy_config_normalizes_legacy_credentials():
+    config = build_playwright_proxy_config("proxy.example:2000:user-name:secret-pass")
+
+    assert config == {
+        "server": "http://proxy.example:2000",
+        "username": "user-name",
+        "password": "secret-pass",
+    }
+
+
+def test_build_playwright_proxy_config_keeps_authenticated_socks5():
+    config = build_playwright_proxy_config("socks5://user:secret@proxy.example:2000")
+
+    assert config == {
+        "server": "socks5://proxy.example:2000",
+        "username": "user",
+        "password": "secret",
+    }


### PR DESCRIPTION
## Summary
- Normalize common host:port:user:pass proxy entries for proxy checks and browser tasks.
- Update proxy health accounting so normalized runtime URLs map back to stored proxy records.
- Re-enable proxies after successful health checks and disable never-successful proxies after repeated failures.

## Tests
- ..\..\.venv\Scripts\python.exe -m pytest tests/test_proxy_utils.py tests/test_proxy_pool.py